### PR TITLE
Add DHH-style monitoring alert guides for multiple channels

### DIFF
--- a/src/content/posts/monitoring/free-domain-monitoring-discord-alerts.md
+++ b/src/content/posts/monitoring/free-domain-monitoring-discord-alerts.md
@@ -1,0 +1,75 @@
+---
+title: "Free Domain Monitoring with Discord Alerts: Keep Your Names Safe"
+author: "Morten Pradsgaard"
+category: "monitoring"
+excerpt: "Stream domain expiry warnings to Discord so your community team and engineers act before disaster."
+readTime: "6 min read"
+metaDescription: "Connect Exit1.dev’s free domain monitoring to Discord webhooks, embed templates, and renewal workflows to prevent losing critical domains."
+---
+
+# Free Domain Monitoring with Discord Alerts: Don’t Let Your URL Slip Away
+
+Lose a domain and everything collapses—site, email, API endpoints, trust. Exit1.dev’s free domain monitoring plus Discord alerts keeps expiry warnings front and center for the people who actually care about your brand.
+
+## Why Discord Is a Smart Domain Watchtower
+
+- **Server-wide visibility**: Pin warnings in `#status` or `#ops` so moderators and engineers know the clock is ticking.
+- **Role mentions**: Ping `@ops` and `@finance` simultaneously. The folks with the credit cards can’t pretend they didn’t see it.
+- **Automation friendly**: Use bots to log alerts, open tickets, or DM the on-call engineer. Discord isn’t just memes—it’s process.
+
+## Set Up the Integration
+
+1. **Create a Discord webhook**
+   - In the status channel settings, open **Integrations → Webhooks** and create one named “Exit1.dev Domain Monitor.”
+2. **Configure Exit1.dev**
+   - Add every domain to Exit1.dev. Under **Notifications**, choose **Discord webhook**, paste the URL, and enable warning + expired events.
+3. **Fire a test alert**
+   - Trigger a test to confirm the embed lands cleanly. It should show domain, expiry, registrar, and runbook link without extra clicks.
+
+## Embed Blueprint
+
+```
+{
+  "username": "Exit1.dev Domain Monitor",
+  "embeds": [
+    {
+      "title": "🚩 Domain Expiry Warning",
+      "description": "`exit1.dev` expires in 21 days.",
+      "color": 15105570,
+      "fields": [
+        { "name": "Registrar", "value": "Namecheap" },
+        { "name": "Next Step", "value": "Renew or extend term" }
+      ],
+      "footer": { "text": "Check again: 2025-01-20 09:00 UTC" }
+    }
+  ]
+}
+```
+
+Mention roles, drop registrar URLs, and add staging vs. production tags. The embed should scream urgency.
+
+## Build the Renewal Muscle
+
+- **Thread the work**: First response claims the renewal. Track registrar logins, approvals, and confirmation numbers in-thread.
+- **Set reminders**: Use `/remind` or a bot to ping the thread at 7 days, 3 days, and 24 hours pre-expiry. Redundancy prevents failure.
+- **Verify success**: After renewal, run a DNS check and post the new expiry date. Proof beats optimism.
+- **Update docs**: Link to your domain inventory or CMDB. Keep everything aligned.
+
+## When to Go Beyond Free
+
+Exit1.dev already covers unlimited domain monitors and Discord alerts. Upgrade only if you need:
+
+- Automated registrar integrations with approval workflows.
+- Portfolio management for dozens of brands.
+- Compliance attestations that auditors obsess over.
+
+Otherwise, keep your money and keep your domains.
+
+## Act Today
+
+1. Inventory production, staging, and marketing domains.
+2. Drop them into Exit1.dev and attach the Discord webhook.
+3. Run a renewal drill so nobody blanks when the warning hits.
+
+Handle this now or start budgeting to buy your own name back from a squatter.
+

--- a/src/content/posts/monitoring/free-domain-monitoring-slack-alerts.md
+++ b/src/content/posts/monitoring/free-domain-monitoring-slack-alerts.md
@@ -1,0 +1,66 @@
+---
+title: "Free Domain Monitoring with Slack Alerts: Guard Your DNS Like a Hawk"
+author: "Morten Pradsgaard"
+category: "monitoring"
+excerpt: "Pipe domain expiry warnings from Exit1.dev into Slack so you never lose a name to negligence."
+readTime: "6 min read"
+metaDescription: "Monitor domain expirations for free and wire alerts into Slack channels, ownership workflows, and renewal drills to prevent outages."
+---
+
+# Free Domain Monitoring with Slack Alerts: Stop Losing Domains Like Amateurs
+
+Letting a domain expire is the fastest way to light your brand on fire. Customers can’t reach you, email breaks, and some squatter buys the name before you wake up. Exit1.dev’s free domain monitoring with Slack alerts keeps the countdown in everyone’s face.
+
+## Why Slack Works for Domain Renewals
+
+- **Public pressure**: When `#platform` sees a domain expiring in 15 days, someone will jump on it.
+- **Threaded coordination**: Track registrar logins, approvals, and payment receipts in one thread.
+- **Workflow automation**: Trigger renewal checklists or ticket creation with Slack reactions and Workflow Builder.
+
+## Configure Domain Alerts in Slack
+
+1. **Spin up a Slack webhook**
+   - Use [Incoming Webhooks](https://api.slack.com/messaging/webhooks) to point alerts at a channel like `#domain-ops` or straight into `#infrastructure` if you want maximum visibility.
+2. **Create domain monitors**
+   - In Exit1.dev, add each domain you own. Under **Notifications**, choose **Slack webhook**, paste the URL, and enable “Domain expiry warning” and “Domain expired.”
+3. **Test the flow**
+   - Send a test alert. Adjust the copy until it shows the domain, registrar, and renewal deadline without scrolling.
+
+## Sample Slack Domain Alert
+
+```
+:triangular_flag_on_post: *Domain Expiry Warning*
+Domain: exit1.dev
+Registrar: Namecheap
+Expires in: 30 days
+Renewal playbook: https://runbooks.exit1.dev/domain-renewal
+Owner: ops@yourcompany.com
+```
+
+Make it obvious who needs to pay the invoice. Add billing links if your registrar supports direct renewals.
+
+## Lock In a Renewal Routine
+
+- **Assign an owner instantly**: First reply in the thread takes the task. No ghosting.
+- **Confirm payment**: Drop a screenshot or invoice number once the registrar renews the domain.
+- **Schedule sanity checks**: Use `/remind` to ping the channel seven days before expiry and again 24 hours before. Redundancy saves careers.
+- **Update documentation**: Post the new expiry date to your asset tracker or CMDB right in the thread.
+
+## When Free Monitoring Is Enough
+
+Exit1.dev covers unlimited domain monitors, Slack alerts, and global uptime checks. Pay extra only if you need:
+
+- Registrar API automation across dozens of brands.
+- Compliance workflows with mandatory approvals.
+- Managed domain portfolios.
+
+Otherwise, Slack plus discipline keeps your names safe.
+
+## Take Action Now
+
+1. List every domain you rely on—prod, staging, marketing microsites.
+2. Add them to Exit1.dev with Slack alerts enabled.
+3. Run a renewal tabletop so the team can’t feign surprise.
+
+Do it and you’ll never again explain to leadership why the homepage now hosts casino ads.
+

--- a/src/content/posts/monitoring/free-ssl-monitoring-discord-alerts.md
+++ b/src/content/posts/monitoring/free-ssl-monitoring-discord-alerts.md
@@ -1,0 +1,75 @@
+---
+title: "Free SSL Monitoring with Discord Alerts: Protect Trust in Your Server"
+author: "Morten Pradsgaard"
+category: "monitoring"
+excerpt: "Stream SSL expiry alerts into Discord so your community never gets blindsided by browser errors."
+readTime: "6 min read"
+metaDescription: "Use Exit1.dev’s free SSL monitoring with Discord webhooks, embed templates, and renewal workflows to prevent certificate expirations."
+---
+
+# Free SSL Monitoring with Discord Alerts: Stop Serving Scary Warnings
+
+Your community doesn’t care why the SSL certificate died—they just see Chrome screaming “Not Secure” and bail. Plug Exit1.dev’s free SSL monitoring into Discord and you’ll know about expiring certs before the mob forms.
+
+## Why Discord Works for SSL Alerts
+
+- **Real-time transparency**: Post expiry countdowns in a locked `#status` channel. Users see you’re on it, not asleep.
+- **Role mentions**: Ping `@infrastructure` or `@mods` the second a warning hits. Accountability in plain sight.
+- **Automation hooks**: Use bots to log the alert, create tickets, or DM the on-call engineer. Discord isn’t just memes—it’s workflows.
+
+## Configure the Integration
+
+1. **Make a Discord webhook**
+   - In server settings for your status channel, open **Integrations → Webhooks** and create one named “Exit1.dev SSL Monitor.”
+2. **Add it to Exit1.dev**
+   - Create SSL monitors for each domain. Under **Notifications**, choose **Discord webhook**, paste the URL, and enable expiry warnings and expired alerts.
+3. **Test aggressively**
+   - Trigger a test alert. If the embed isn’t crystal clear, fix it now. You want domain, expiry date, and next steps at a glance.
+
+## Recommended Discord Embed
+
+```
+{
+  "username": "Exit1.dev SSL Monitor",
+  "embeds": [
+    {
+      "title": "🔒 SSL Expiry Warning",
+      "description": "`cdn.exit1.dev` certificate expires in 10 days.",
+      "color": 3447003,
+      "fields": [
+        { "name": "Issuer", "value": "Let's Encrypt R3" },
+        { "name": "Next Step", "value": "Run renewal playbook" }
+      ],
+      "footer": { "text": "Check again: 2025-01-15 08:00 UTC" }
+    }
+  ]
+}
+```
+
+Add role mentions, runbook links, or staging vs. production tags. The embed should make the response plan obvious.
+
+## Drive the Renewal Process
+
+- **Assign ownership in-thread**: First responder claims the renewal. Threads show progress without flooding the main channel.
+- **Schedule follow-ups**: Use bots or `/remind` to nag the team three days before expiry. No more “forgot.”
+- **Automate verification**: Have your CI/CD pipeline post back to the thread once the new cert is live.
+- **Document closure**: Post the new expiry date and any lessons learned. Transparency earns trust.
+
+## When Free Is Enough
+
+Exit1.dev already gives you unlimited SSL monitors, Discord alerts, and status pages without charging a cent. Upgrade only if you need:
+
+- Enterprise PKI integrations.
+- Multi-tenant reporting for regulated industries.
+- Dedicated support contracts.
+
+Otherwise, the free stack plus discipline keeps certificates fresh.
+
+## Do It Now
+
+1. Inventory every domain hitting production.
+2. Create SSL monitors in Exit1.dev with the Discord webhook attached.
+3. Run a renewal drill so the team knows the play.
+
+Your community deserves green padlocks, not panic screens. Handle it.
+

--- a/src/content/posts/monitoring/free-ssl-monitoring-email-alerts.md
+++ b/src/content/posts/monitoring/free-ssl-monitoring-email-alerts.md
@@ -1,0 +1,69 @@
+---
+title: "Free SSL Monitoring with Email Alerts: Never Miss a Renewal"
+author: "Morten Pradsgaard"
+category: "monitoring"
+excerpt: "Use Exit1.dev’s free SSL monitor with disciplined email alerts to renew certificates before customers see warnings."
+readTime: "7 min read"
+metaDescription: "Combine free SSL monitoring and sharp email alert workflows to prevent certificate expirations and keep trust intact."
+---
+
+# Free SSL Monitoring with Email Alerts: Renew Before Browsers Riot
+
+If your SSL certificate expires, you deserve every angry ticket that hits support. Exit1.dev’s free SSL monitoring plus ruthless email workflows makes sure you renew before browsers throw red screens at customers.
+
+## Email Works—If You Respect It
+
+- **Universal delivery**: Legal, finance, partners—they all have email. No excuses about who got pinged.
+- **Permanent record**: Audit teams want proof you saw the warnings. Email keeps the receipts.
+- **Automation playground**: Filters, forwarding, calendar triggers—email can nag you harder than any chat bot if you configure it.
+
+## Set Up the Alerts
+
+1. **Create a dedicated mailing list**
+   - Use something like `ssl-alerts@yourcompany.com`. Include engineering, ops, and whoever signs the certs.
+2. **Configure Exit1.dev**
+   - Add SSL monitors for every domain or wildcard. Under **Notifications**, add the mailing list and enable both expiry warnings and expired alerts.
+3. **Send a test**
+   - Fire the test email. If it lands in spam, fix SPF/DKIM and update filters. SSL alerts don’t belong in Promotions.
+4. **Define ownership**
+   - Decide who replies-all with the renewal plan. If nobody owns the thread, nothing happens.
+
+## Craft Emails People Read
+
+```
+Subject: [SSL][14 DAYS] app.exit1.dev certificate expires soon
+
+Domain: app.exit1.dev
+Current expiry: 2025-01-28 12:00 UTC
+Issuer: Let's Encrypt R3
+Renewal playbook: https://runbooks.exit1.dev/renew-ssl
+Owner: sre@yourcompany.com
+```
+
+Short, factual, mercilessly clear. The subject shows severity and timeline; the body points straight to the fix.
+
+## Build a Real Renewal Process
+
+- **Label and color-code**: Tag SSL alerts as “Critical” so they jump out in every inbox.
+- **Auto-forward on silence**: If nobody responds within 30 minutes, forward to leadership. Shame is a feature.
+- **Block time**: Auto-create a calendar event five days before expiry. Someone must click “Accept.”
+- **Close the loop**: Reply-all with the new expiry timestamp after renewal. The thread becomes the audit log.
+
+## When to Add More Tooling
+
+Exit1.dev gives you unlimited SSL monitors, email alerts, and status pages for free. Upgrade only if you need:
+
+- Automated certificate deployment across dozens of load balancers.
+- Hardware-backed key storage and compliance attestations.
+- 24/7 managed rotations.
+
+If that’s not you, stick with the free stack and handle renewals like an adult.
+
+## Execute Now
+
+1. Inventory every certificate in production.
+2. Add them to Exit1.dev with the email list attached.
+3. Run a renewal drill so the team can’t claim ignorance.
+
+Do this and you’ll never again ship a “Not Secure” warning to paying customers.
+

--- a/src/content/posts/monitoring/free-ssl-monitoring-slack-alerts.md
+++ b/src/content/posts/monitoring/free-ssl-monitoring-slack-alerts.md
@@ -1,0 +1,67 @@
+---
+title: "Free SSL Monitoring with Slack Alerts: Never Let Certificates Rot"
+author: "Morten Pradsgaard"
+category: "monitoring"
+excerpt: "Catch SSL expirations before they torch trust by piping Exit1.dev alerts into Slack."
+readTime: "6 min read"
+metaDescription: "Set up free SSL certificate monitoring with Slack alerts, renewal workflows, and channel strategy to prevent embarrassing expirations."
+---
+
+# Free SSL Monitoring with Slack Alerts: Stop Shipwrecks Before They Start
+
+Letting an SSL cert expire is amateur hour. Browsers explode with warnings, conversion tanks, and trust evaporates overnight. The fix? Exit1.dev’s free SSL monitoring plus Slack alerts that nag you until you renew. No excuses.
+
+## Why Slack Is the Right Hammer for SSL Alerts
+
+- **Instant humiliation**: The whole team sees the countdown, so no one can shrug and say “I didn’t know.”
+- **Threaded follow-up**: Track renewal steps right under the alert. Zero context switching.
+- **Automation friendly**: Route alerts into Jira, Notion, or your CI pipeline with Slack workflows. Bureaucracy handled.
+
+## Set Up SSL Alerts in Slack
+
+1. **Create the Slack webhook**
+   - Add a Slack app via [Incoming Webhooks](https://api.slack.com/messaging/webhooks). Aim it at a channel like `#ssl-ops` or toss it straight into `#platform` if you enjoy public accountability.
+2. **Configure the monitor**
+   - In Exit1.dev, create an SSL monitor for each domain or wildcard. Under **Notifications**, select **Slack webhook** and paste the URL.
+   - Enable both “Expiry warning” and “Expired certificate” events. You want the countdown and the red alarm.
+3. **Test and tune**
+   - Send a test alert. If it lands flat, fix formatting now. Include the domain, expiry date, and runbook link.
+
+## Sample Slack SSL Alert
+
+```
+:lock: *SSL Expiry Warning*
+Domain: app.exit1.dev
+Expires in: 14 days
+Issuer: Let's Encrypt R3
+Runbook: https://runbooks.exit1.dev/renew-ssl
+Owner: SRE Team
+```
+
+Make the message impossible to misunderstand. If someone has to expand threads to find the expiry date, rewrite it.
+
+## Build a Renewal Workflow That Actually Happens
+
+- **Assign an owner immediately**: First response claims the task. Slack threads make accountability obvious.
+- **Schedule the work**: Use `/remind` or Workflow Builder to drop a calendar hold three days before expiry.
+- **Automate certificate deployment**: Tie the Slack alert to a script that checks your ACME client or triggers Terraform plans.
+- **Close the loop**: Post the new expiry date once renewed. Celebrate not shipping broken HTTPS.
+
+## When to Pay for More
+
+Exit1.dev’s free tier covers unlimited SSL monitors and Slack alerts. Pay up only if you need:
+
+- Hardware security module (HSM) integrations.
+- Multi-cloud certificate automation tied to provisioning.
+- Compliance attestation features.
+
+Otherwise, stay on the free train and stop letting certificates rot.
+
+## Ship It Today
+
+1. List every domain and wildcard you own.
+2. Create SSL monitors in Exit1.dev with Slack alerts attached.
+3. Run a tabletop exercise so everyone knows what to do when the warning fires.
+
+That’s how you keep HTTPS solid and your reputation intact.
+

--- a/src/content/posts/monitoring/free-uptime-monitor-email-alerts.md
+++ b/src/content/posts/monitoring/free-uptime-monitor-email-alerts.md
@@ -1,0 +1,79 @@
+---
+title: "Free Uptime Monitoring with Email Alerts: Inbox Discipline for Real Incidents"
+author: "Morten Pradsgaard"
+category: "monitoring"
+excerpt: "Use Exit1.dev’s free uptime monitor with sharp email alerts that cut through the noise."
+readTime: "7 min read"
+metaDescription: "Pair a free uptime monitor with well-tuned email alerts, filters, and escalation tactics to catch outages fast without paying a cent."
+---
+
+# Free Uptime Monitoring with Email Alerts: Inbox Discipline or Bust
+
+Email alerts get mocked because most teams treat the inbox like a trash heap. Clean it up and Exit1.dev’s free uptime monitor becomes a brutally reliable signal. No SMS charges. No chat noise. Just crisp alerts that land where executives, engineers, and compliance robots already live.
+
+## Why Email Still Matters (If You Stop Being Lazy)
+
+- **Universal access**: Every exec, contractor, and vendor already has email. No onboarding circus.
+- **Audit trail**: Compliance teams love archived emails. Give them receipts instead of screenshots.
+- **Filter power**: Gmail, Outlook, Fastmail—doesn’t matter. You can slice, color, auto-forward, and escalate with rules you control.
+
+If your inbox is a wasteland, fix that. The tool isn’t the problem; your process is.
+
+## Wire Up Exit1.dev Email Alerts Fast
+
+1. **Create or pick a distribution list**
+   - Use an address like `uptime-alerts@yourcompany.com`. Make sure it hits everyone who must react.
+2. **Add the list to Exit1.dev**
+   - Edit your monitor, open **Notifications**, and drop in the email address. Select the events that actually require action: downtime start, recovery, SSL expiry.
+3. **Send a test**
+   - Smash the **Send test** button. If it lands in spam, fix your filters immediately. Downtime alerts don’t belong in Promotions.
+4. **Document response rules**
+   - Decide who owns the inbox during business hours and after hours. Put it in writing. No more “I thought you had it.”
+
+## Build Ruthless Email Filters
+
+- **Priority inbox**: Label uptime alerts as “Critical” or slap a color-coded tag. They should scream at you.
+- **Auto-forwarding**: Forward after five minutes to escalation targets if nobody replies. Gmail filters plus filters in your email client make this painless.
+- **Mobile push**: Turn on high-priority notifications for the alert label only. Your phone should light up for outages, not newsletters.
+- **Calendar reminders**: Auto-create a calendar event when an incident email arrives. If it’s still on the calendar an hour later, your process is broken.
+
+## Suggested Email Template
+
+```
+Subject: [PROD][DOWN] api.exit1.dev failing health checks
+
+Service: api.exit1.dev
+Regions: US-East, EU-West, APAC
+Error rate: 71% (threshold 5%)
+Detected: 2025-01-14 09:43 UTC
+Runbook: https://runbooks.exit1.dev/api-outage
+Owner on call: platform@yourcompany.com
+```
+
+Short, blunt, informative. No poetry. The subject line should tell you severity, environment, and system without opening the email.
+
+## Keep the Signal Clean
+
+- **Purge stale recipients**: If someone hasn’t responded to an alert in three months, remove them. Freeloaders mute the list.
+- **Review weekly**: Audit false positives and fix thresholds. Inbox fatigue is self-inflicted.
+- **Bundle FYIs**: Route low-severity warnings to a digest instead of the main list. Save the red siren for real outages.
+- **Close the loop**: Reply-all with the fix summary. The thread becomes the incident log.
+
+## When to Escalate Beyond Email
+
+Exit1.dev’s free plan gives you unlimited monitors, 30-second probes, email alerts, and status pages. Only add SMS, chat, or phone trees if:
+
+- Regulators demand multi-channel paging.
+- You run 24/7 on-call rotations that can’t trust inboxes at 3 a.m.
+- You want integrated ticketing or ITSM workflows.
+
+Otherwise, email plus discipline is enough. Do the work and stop blaming the channel.
+
+## Next Steps
+
+1. Set up the alert distribution list.
+2. Add it to your Exit1.dev monitors and test.
+3. Write the response rules and make the team rehearse.
+
+That’s it. Free uptime monitoring, zero new tools, and email that finally pulls its weight.
+

--- a/src/content/posts/monitoring/free-uptime-monitor-slack-integration.md
+++ b/src/content/posts/monitoring/free-uptime-monitor-slack-integration.md
@@ -1,0 +1,95 @@
+---
+title: "Free Uptime Monitor with Slack Integration: 2025 Incident Playbook"
+author: "Morten Pradsgaard"
+category: "monitoring"
+excerpt: "Wire Exit1.dev's free uptime monitor to Slack and make outages impossible to ignore."
+readTime: "8 min read"
+metaDescription: "Hook a free uptime monitor into Slack for blunt, instant alerts, disciplined channels, and no-nonsense incident response."
+---
+
+# Free Uptime Monitor with Slack Integration: Ship Alerts Your Team Actually Sees
+
+Slack is where the real work chatter happens. If you still expect engineers to babysit inboxes, you deserve the downtime surprises you keep getting. Wire Exit1.dev’s free uptime monitor into Slack and you’ll stop guessing who saw the alert—because everyone will.
+
+## Slack Beats Pager Spam. Here’s Why.
+
+- **Visibility you can’t ignore**: Alerts drop into the same channels where code reviews and deployment debates already live. No more “missed the email” excuses.
+- **Context in one place**: Threads keep the timeline, runbooks, and status updates glued to the original alert.
+- **Automation ready to fire**: Slack workflows, bot users, and custom reactions trigger the next move without touching a dashboard.
+
+Exit1.dev ships Slack webhooks on the free tier. No upsell. No nickel-and-diming. Plug it in and get on with building.
+
+## Set Up Exit1.dev → Slack in Five Minutes
+
+1. **Create a Slack incoming webhook**
+   - Head to Slack’s [Incoming Webhooks](https://api.slack.com/messaging/webhooks) page and add a new app to your workspace.
+   - Pick the channel where you want truth to land: `#incidents`, `#platform-oncall`, whatever cuts through the noise.
+2. **Copy the webhook URL**
+   - Slack hands you a long HTTPS URL. Treat it like a token; anyone holding it can post as you.
+3. **Drop it into Exit1.dev**
+   - Edit your monitor, open **Notifications**, choose **Slack webhook**, and paste the URL.
+   - Decide which events matter: downtime, recovery, SSL expiry, performance regression. Keep the list tight.
+4. **Punch the test button**
+   - Fire a test alert or toggle maintenance mode to simulate downtime. If the message doesn’t hit Slack, fix it now—not at 2 a.m.
+
+That’s the setup. No scripts. No Lambda detours. Just working alerts.
+
+## Architect Your Channels Like You Mean It
+
+- **Dedicated incident channel**: A public `#incidents` channel keeps everyone honest. Hide nothing; you’ll move faster.
+- **Focused product streams**: Multiple apps? Split channels like `#checkout-uptime` or `#api-monitoring` so owners stay accountable.
+- **Stakeholder digest**: Pipe resolved alerts to a read-only `#status-feed` for support and exec updates. They get signal without hijacking the incident room.
+
+Use Slack permissions. Stop random chatter from burying the messages that matter.
+
+## Automate the Next Move
+
+- **Threads or it didn’t happen**: Spin up a thread for every alert. Drop runbooks, timelines, screenshots—build the postmortem as you fight the fire.
+- **Emoji routing**: Make :eyes: assign the incident commander. Let :rotating_light: trigger escalation workflows. Human intent, automated follow-through.
+- **Slash command shortcuts**: Wire `/pagerduty`, `/statuspage`, or custom commands to update external tools without leaving Slack.
+- **Reminder discipline**: Schedule reminders on open threads. Stale incidents are a choice.
+
+## Steal This Slack Alert Template
+
+```
+:rotating_light: *Production API DOWN*
+Service: api.exit1.dev
+Regions: US-East, EU-West, APAC
+Error rate: 65% (threshold 5%)
+Detected: 2025-01-14 09:43 UTC
+Runbook: https://runbooks.exit1.dev/api-outage
+```
+
+Tweak the copy so it screams severity. Add owner tags or runbook links. If someone has to guess what to do next, you failed.
+
+## Keep Signal High, Noise Low
+
+- **Short polling for critical paths**: Mission-critical APIs deserve 30-second checks. Brochure sites can chill at 60 seconds.
+- **Confirmation probes**: Require two regions to agree before firing. False positives destroy trust faster than downtime.
+- **Segment by severity**: Performance warnings go to a quieter channel. Hard downtime hits the main incident room.
+- **Review weekly**: Audit alert accuracy in ops reviews. Slack isn’t a landfill; take out the trash.
+
+## Spread the Visibility
+
+- **Customer success**: Mirror high-severity alerts into their channel so they can call customers before Twitter does.
+- **Sales**: Give reps a read-only feed. Nothing kills a renewal like “let me check with engineering.”
+- **Leadership**: Send automated digests summarizing uptime and incidents. Facts beat status theater.
+
+## When You Actually Need Paid Tools
+
+Exit1.dev’s free plan handles unlimited monitors, global probes, Slack webhooks, and status pages. Pay up only if you need:
+
+- Complex on-call rotations with SMS/phone escalation.
+- Compliance evidence beyond Slack’s retention limits.
+- Full observability stacks—traces, logs, the works.
+
+Until then, keep your cash and run with the free stack.
+
+## Do the Work Now
+
+1. Create your free Exit1.dev account.
+2. Paste the Slack webhook into your monitor.
+3. Fire a test, document the workflow, and make the team practice once.
+
+That’s the whole playbook. Free uptime monitoring plus Slack alerts means incidents stop slipping through the cracks, and you stay focused on shipping real features.
+

--- a/src/content/posts/monitoring/free-website-monitor-discord-integration.md
+++ b/src/content/posts/monitoring/free-website-monitor-discord-integration.md
@@ -1,0 +1,89 @@
+---
+title: "Free Website Monitor with Discord Alerts: Keep Communities Informed"
+author: "Morten Pradsgaard"
+category: "monitoring"
+excerpt: "Pipe Exit1.dev uptime alerts into Discord so your community hears the truth first."
+readTime: "7 min read"
+metaDescription: "Connect a free website monitor to Discord webhooks for blunt, real-time outage alerts, disciplined channels, and proactive community updates."
+---
+
+# Free Website Monitor with Discord Integration: Tell Your Community the Truth First
+
+Discord is the town square for your product. If you let rumor threads explain downtime before you do, you’re begging for churn. Exit1.dev’s free website monitor now speaks Discord natively, so you can hit your server with the facts before someone invents a conspiracy theory.
+
+## Why Discord Wins for Outage Alerts
+
+- **Community expects transparency**: Your players, customers, and moderators live in Discord. Meet them there or watch trust evaporate.
+- **Channel control**: Post critical incidents in a locked `#status` channel, drip maintenance notes into `#announcements`, and stop the chaos.
+- **Automation playground**: Webhook embeds let you flag roles, trigger bot workflows, and format clean status cards without hacking together a bot.
+
+The free plan includes Discord webhooks. No “enterprise tier” bait-and-switch. Use it.
+
+## Wire Exit1.dev to Discord Without Drama
+
+1. **Create a Discord webhook**
+   - In the server settings for `#status` (or any channel built for truth), open **Integrations → Webhooks** and click **New Webhook**.
+   - Give it a name that screams authority—“Exit1.dev Monitor” works.
+2. **Copy the webhook URL**
+   - Discord hands you a unique URL tied to that channel. Guard it. Anyone with the link can post as you.
+3. **Drop it into Exit1.dev**
+   - Edit your monitor, open **Notifications**, choose **Discord webhook**, and paste.
+   - Tick the events worth broadcasting: downtime, recovery, SSL expiry, performance regression. Don’t flood the channel with fluff.
+4. **Fire a test**
+   - Trigger a test alert. If the embed doesn’t land exactly how you want, tweak now instead of during a live incident.
+
+That’s the whole integration. No bots, no extra hosting, no excuses.
+
+## Steal This Discord Embed Format
+
+```
+{
+  "username": "Exit1.dev Monitor",
+  "embeds": [
+    {
+      "title": "🚨 Website Down",
+      "description": "`app.exit1.dev` is failing health checks.",
+      "color": 15158332,
+      "fields": [
+        { "name": "Error Rate", "value": "72%" },
+        { "name": "Regions", "value": "US-East, EU-West, APAC" }
+      ],
+      "footer": { "text": "Detected 2025-01-14 10:07 UTC" }
+    }
+  ]
+}
+```
+
+Make it your own—change colors, drop runbook links, mention roles like `@moderators` when humans need to jump in. The alert should answer “what, where, now what?” in one hit.
+
+## Keep Discord Alert Hygiene Tight
+
+- **Lock the status channel**: Only the webhook should post. Chatter belongs in threads, not the main feed.
+- **Pin recoveries**: When you fix the issue, pin the recovery embed or start a summary thread. Don’t leave the last message screaming “DOWN.”
+- **Auto-answer repeat questions**: Use bots (MEE6, Carl-bot) to respond to “is the site down?” with the status post.
+- **Archive incident threads**: Keep a read-only archive channel for transparency and postmortems without cluttering live chat.
+
+## Go Beyond Outage Blasts
+
+- **Maintenance countdowns**: Schedule a post 24 hours before planned downtime so your community isn’t blindsided.
+- **Launch updates**: Reuse the webhook to ship changelog snippets or deployment successes. Celebrate the wins.
+- **VIP segmentation**: Send premium members a role-specific ping with deeper technical context or compensation instructions.
+
+## When You Outgrow “Free”
+
+Exit1.dev’s free website monitor already brings global checks, SSL tracking, and Discord alerts. Upgrade only if you need:
+
+- Voice/SMS paging for hardcore on-call rotations.
+- Compliance paperwork that Discord can’t satisfy.
+- Full observability stacks—logs, traces, the heavy artillery.
+
+Until then, keep your money and keep your community informed.
+
+## Ship It Today
+
+1. Sign up for Exit1.dev’s free monitor.
+2. Paste the Discord webhook into your monitor settings.
+3. Test the embed, write the playbook, and tell your server where to look when things break.
+
+Do this now and your community stops guessing. They’ll know you’re on it, and you’ll keep them loyal.
+


### PR DESCRIPTION
## Summary
- rewrite the Slack and Discord integration posts in a blunt, DHH-inspired tone while keeping setup guidance intact
- add new guides covering free uptime email alerts plus SSL and domain monitoring with Slack, Discord, and email workflows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d6f6060a388325b4713dbee351d04f