### PR TITLE
Add internal linking section to blog posts

### DIFF
--- a/src/content/posts/ai/ai-anomaly-detection-monitoring.md
+++ b/src/content/posts/ai/ai-anomaly-detection-monitoring.md
@@ -84,3 +84,11 @@ Adjust sensitivity and retrain with better samples. False alarms beat silent fai
 AI anomaly detection turns monitoring from passive logging into early warning. Hook it up or keep firefighting while your competition stays online.
 
 *Beta waitlist: [Join now](https://exit1.dev). Shape the future.*
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/ai/ai-integration-for-website-monitoring.md
+++ b/src/content/posts/ai/ai-integration-for-website-monitoring.md
@@ -365,3 +365,11 @@ Keep humans in the loop for now. Let AI tee up actions but require a manual swin
 AI integration trims the fat from monitoring by automating the boring parts and surfacing only what matters. Set it up once and spend your time building features instead of babysitting dashboards.
 
 *Try exit1.dev's AI-ready platform [here](https://exit1.dev). Build workflows that work.*
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/best-free-uptime-monitoring-tools.md
+++ b/src/content/posts/monitoring/best-free-uptime-monitoring-tools.md
@@ -171,3 +171,11 @@ Free uptime monitoring only matters if it keeps you in the loop without shackles
 
 - Wikipedia: Synthetic monitoring — https://en.wikipedia.org/wiki/Synthetic_monitoring
 - Google SRE Book: Monitoring Distributed Systems — https://sre.google/sre-book/monitoring-distributed-systems/
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/best-website-monitoring-service-2025.md
+++ b/src/content/posts/monitoring/best-website-monitoring-service-2025.md
@@ -339,3 +339,11 @@ Ready to get started? [Try Exit1.dev's free tier](https://app.exit1.dev/) and se
 - [UptimeRobot Official Website](https://uptimerobot.com/) - Popular free monitoring service
 - [Better Stack](https://betterstack.com/) - Premium monitoring platform
 - [Google's Web Vitals](https://web.dev/articles/vitals) - Performance metrics that matter
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/building-exit1-dev-how-i-made-premium-monitoring-free.md
+++ b/src/content/posts/monitoring/building-exit1-dev-how-i-made-premium-monitoring-free.md
@@ -416,3 +416,11 @@ Related: [Get Started](/blog/getting-started), [Free Tools](/blog/free-website-m
 - Firestore Real-time Updates — https://firebase.google.com/docs/firestore/query-data/listen
 - BigQuery Analytics — https://cloud.google.com/bigquery/docs
 - RDAP Protocol — https://datatracker.ietf.org/doc/html/rfc7483
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/free-domain-monitoring-discord-alerts.md
+++ b/src/content/posts/monitoring/free-domain-monitoring-discord-alerts.md
@@ -73,3 +73,11 @@ Otherwise, keep your money and keep your domains.
 
 Handle this now or start budgeting to buy your own name back from a squatter.
 
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/free-domain-monitoring-slack-alerts.md
+++ b/src/content/posts/monitoring/free-domain-monitoring-slack-alerts.md
@@ -64,3 +64,11 @@ Otherwise, Slack plus discipline keeps your names safe.
 
 Do it and you’ll never again explain to leadership why the homepage now hosts casino ads.
 
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/free-ssl-certificate-monitoring.md
+++ b/src/content/posts/monitoring/free-ssl-certificate-monitoring.md
@@ -127,3 +127,11 @@ Monitor or regret. Free works.
 - Let's Encrypt: Documentation — https://letsencrypt.org/docs/
 - Mozilla: SSL Configuration Generator — https://ssl-config.mozilla.org/
 - Cloudflare Learning: What is SSL/TLS? — https://www.cloudflare.com/learning/ssl/what-is-ssl/
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/free-ssl-monitoring-discord-alerts.md
+++ b/src/content/posts/monitoring/free-ssl-monitoring-discord-alerts.md
@@ -73,3 +73,11 @@ Otherwise, the free stack plus discipline keeps certificates fresh.
 
 Your community deserves green padlocks, not panic screens. Handle it.
 
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/free-ssl-monitoring-email-alerts.md
+++ b/src/content/posts/monitoring/free-ssl-monitoring-email-alerts.md
@@ -67,3 +67,11 @@ If that’s not you, stick with the free stack and handle renewals like an adult
 
 Do this and you’ll never again ship a “Not Secure” warning to paying customers.
 
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/free-ssl-monitoring-slack-alerts.md
+++ b/src/content/posts/monitoring/free-ssl-monitoring-slack-alerts.md
@@ -65,3 +65,11 @@ Otherwise, stay on the free train and stop letting certificates rot.
 
 That’s how you keep HTTPS solid and your reputation intact.
 
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/free-uptime-monitor-checklist.md
+++ b/src/content/posts/monitoring/free-uptime-monitor-checklist.md
@@ -100,3 +100,11 @@ Regulators don't care that it's free. Your free uptime monitor still has to resp
 
 Run your current provider through this free uptime monitor checklist. If they miss two items, stop justifying mediocrity and migrate to Exit1.dev. It ships every requirement without the upsell song and dance.
 
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/free-uptime-monitor-email-alerts.md
+++ b/src/content/posts/monitoring/free-uptime-monitor-email-alerts.md
@@ -77,3 +77,11 @@ Otherwise, email plus discipline is enough. Do the work and stop blaming the cha
 
 That’s it. Free uptime monitoring, zero new tools, and email that finally pulls its weight.
 
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/free-uptime-monitor-for-saas.md
+++ b/src/content/posts/monitoring/free-uptime-monitor-for-saas.md
@@ -81,3 +81,11 @@ A B2B SaaS company serving 5,000 customers ditched a pricey legacy suite for Exi
 
 SaaS reliability leaders don’t have to choose between fiscal discipline and uptime. Deploy Exit1.dev as your free uptime monitor, then layer in traces or logs when the product justifies the spend. Until then, keep the stack lean and the service green.
 
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/free-uptime-monitor-slack-integration.md
+++ b/src/content/posts/monitoring/free-uptime-monitor-slack-integration.md
@@ -93,3 +93,11 @@ Until then, keep your cash and run with the free stack.
 
 That’s the whole playbook. Free uptime monitoring plus Slack alerts means incidents stop slipping through the cracks, and you stay focused on shipping real features.
 
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/free-uptime-monitor-vs-paid.md
+++ b/src/content/posts/monitoring/free-uptime-monitor-vs-paid.md
@@ -85,3 +85,11 @@ The "free vs paid" debate is tired. Here’s the truth for 2025: a disciplined t
 
 Start with the free uptime monitor that already gives you enterprise-grade coverage—Exit1.dev. When your architecture demands traces, logs, and compliance checklists, layer in a paid suite. Until then, keep your wallet closed and your uptime high.
 
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/free-vs-paid-website-monitoring.md
+++ b/src/content/posts/monitoring/free-vs-paid-website-monitoring.md
@@ -146,3 +146,11 @@ Related: [101](/blog/website-monitoring-101), [Get Started](/blog/get-started), 
 
 - Google SRE Book: Monitoring Distributed Systems — https://sre.google/sre-book/monitoring-distributed-systems/
 - Wikipedia: Synthetic monitoring — https://en.wikipedia.org/wiki/Synthetic_monitoring
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/free-website-monitor-discord-integration.md
+++ b/src/content/posts/monitoring/free-website-monitor-discord-integration.md
@@ -87,3 +87,11 @@ Until then, keep your money and keep your community informed.
 
 Do this now and your community stops guessing. They’ll know you’re on it, and you’ll keep them loyal.
 
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/free-website-monitoring-for-developers.md
+++ b/src/content/posts/monitoring/free-website-monitoring-for-developers.md
@@ -169,3 +169,11 @@ Tools that help code, not hinder. Start free.
 
 - MDN: Fetch API — https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
 - GitHub Actions: Cron schedule — https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#onschedule
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/free-website-monitoring-for-small-business.md
+++ b/src/content/posts/monitoring/free-website-monitoring-for-small-business.md
@@ -156,3 +156,11 @@ Remember: The best monitoring system is the one you actually use. Start with exi
 
 - AWS Well-Architected: Reliability Pillar — https://docs.aws.amazon.com/wellarchitected/latest/reliability-pillar/welcome.html
 - Google SRE Book: Monitoring Distributed Systems — https://sre.google/sre-book/monitoring-distributed-systems/
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/free-website-monitoring-tools-2025.md
+++ b/src/content/posts/monitoring/free-website-monitoring-tools-2025.md
@@ -442,3 +442,11 @@ Script to eval tools: Check speed, alerts.
 
 - Google SRE Book: Monitoring Distributed Systems — https://sre.google/sre-book/monitoring-distributed-systems/
 - MDN: HTTP response status codes — https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/gdpr-compliant-website-monitor-for-free.md
+++ b/src/content/posts/monitoring/gdpr-compliant-website-monitor-for-free.md
@@ -105,3 +105,11 @@ Instantly. Use the dashboard or API to wipe logs, then carry on like nothing hap
 ### What happens if regulators ask for evidence?
 You export your uptime logs, show the retention policy, and go back to building. That's the whole point.
 
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/importance-of-real-time-alerts.md
+++ b/src/content/posts/monitoring/importance-of-real-time-alerts.md
@@ -298,3 +298,11 @@ Goal: Right alerts, right time, right info. Reduces stress, boosts efficiency, k
 
 - Google SRE Book: Monitoring Distributed Systems — https://sre.google/sre-book/monitoring-distributed-systems/
 - AWS Well-Architected: Reliability Pillar — https://docs.aws.amazon.com/wellarchitected/latest/reliability-pillar/welcome.html
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/intro-to-website-monitoring.md
+++ b/src/content/posts/monitoring/intro-to-website-monitoring.md
@@ -511,3 +511,11 @@ Remember, the best monitoring system is one that helps you sleep better at night
 ---
 
 *Ready to start monitoring your website effectively? [Begin with exit1.dev](https://exit1.dev) and build a monitoring strategy that grows with your business.* 
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/pingdom-free-alternative.md
+++ b/src/content/posts/monitoring/pingdom-free-alternative.md
@@ -174,3 +174,11 @@ Related: [Best Service](/blog/best-website-monitoring-service-2025), [Free vs Pa
 
 - Wikipedia: Synthetic monitoring — https://en.wikipedia.org/wiki/Synthetic_monitoring
 - web.dev: Core Web Vitals — https://web.dev/articles/vitals
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/real-time-vs-5-minute-monitoring.md
+++ b/src/content/posts/monitoring/real-time-vs-5-minute-monitoring.md
@@ -112,3 +112,11 @@ Choose fast. No regrets.
 
 - Google SRE Book: Monitoring Distributed Systems — https://sre.google/sre-book/monitoring-distributed-systems/
 - AWS Well-Architected: Reliability Pillar — https://docs.aws.amazon.com/wellarchitected/latest/reliability-pillar/welcome.html
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/setup-free-uptime-monitor-wordpress.md
+++ b/src/content/posts/monitoring/setup-free-uptime-monitor-wordpress.md
@@ -92,3 +92,11 @@ Exit1.dev gives you response time analytics alongside uptime.
 
 You don’t need another premium plugin to stay online. Wire up Exit1.dev as your free uptime monitor, get 30-second checks, and keep WordPress revenue safe without begging finance for budget.
 
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/ssl-certificate-monitoring-alerts-made-easy-and-why-it-matters.md
+++ b/src/content/posts/monitoring/ssl-certificate-monitoring-alerts-made-easy-and-why-it-matters.md
@@ -92,3 +92,11 @@ Monitor now. Free.
 - Let's Encrypt: Documentation — https://letsencrypt.org/docs/
 - Mozilla: SSL Configuration Generator — https://ssl-config.mozilla.org/
 - Cloudflare Learning: What is SSL/TLS? — https://www.cloudflare.com/learning/ssl/what-is-ssl/
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/statuscake-vs-free-monitoring.md
+++ b/src/content/posts/monitoring/statuscake-vs-free-monitoring.md
@@ -170,3 +170,11 @@ Free often wins. Try exit1.dev.
 
 - Wikipedia: Synthetic monitoring — https://en.wikipedia.org/wiki/Synthetic_monitoring
 - AWS Well-Architected: Reliability Pillar — https://docs.aws.amazon.com/wellarchitected/latest/reliability-pillar/welcome.html
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/understanding-website-downtime.md
+++ b/src/content/posts/monitoring/understanding-website-downtime.md
@@ -166,3 +166,11 @@ Related: [101](/blog/website-monitoring-101), [Alerts](/blog/downtime-alerts-gui
 - AWS Well-Architected: Reliability Pillar — https://docs.aws.amazon.com/wellarchitected/latest/reliability-pillar/welcome.html
 - Google SRE Book: Managing Incidents — https://sre.google/sre-book/managing-incidents/
 - Cloudflare Learning: What is a DDoS attack? — https://www.cloudflare.com/learning/ddos/what-is-a-ddos-attack/
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/uptimerobot-alternatives.md
+++ b/src/content/posts/monitoring/uptimerobot-alternatives.md
@@ -176,3 +176,11 @@ Related: [Best Service](/blog/best-website-monitoring-service-2025), [Free vs Pa
 
 - Wikipedia: Synthetic monitoring — https://en.wikipedia.org/wiki/Synthetic_monitoring
 - Google SRE Book: Monitoring Distributed Systems — https://sre.google/sre-book/monitoring-distributed-systems/
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/uptrends-free-alternative.md
+++ b/src/content/posts/monitoring/uptrends-free-alternative.md
@@ -210,3 +210,11 @@ Enterprise: Uptrends.
 [Start exit1.dev](https://exit1.dev)
 
 Related: [Best Service](/blog/best-website-monitoring-service-2025), [Free vs Paid](/blog/free-vs-paid-website-monitoring), [101](/blog/website-monitoring-101), [Get Started](/blog/get-started) 
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/website-monitoring-101.md
+++ b/src/content/posts/monitoring/website-monitoring-101.md
@@ -115,3 +115,11 @@ Related: [Get Started](/blog/get-started), [Free Tools](/blog/free-website-monit
 - MDN: HTTP response status codes — https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status
 - web.dev: Core Web Vitals — https://web.dev/articles/vitals
 - Google SRE Book: Monitoring Distributed Systems — https://sre.google/sre-book/monitoring-distributed-systems/
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+

--- a/src/content/posts/monitoring/website-monitoring-best-practices-2025.md
+++ b/src/content/posts/monitoring/website-monitoring-best-practices-2025.md
@@ -1230,3 +1230,11 @@ Score your monitoring.
 - Google SRE Book: Monitoring Distributed Systems — https://sre.google/sre-book/monitoring-distributed-systems/
 - web.dev: Core Web Vitals — https://web.dev/articles/vitals
 - AWS Well-Architected: Reliability Pillar — https://docs.aws.amazon.com/wellarchitected/latest/reliability-pillar/welcome.html
+
+## Recommended Free Monitoring Resources
+
+- [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) – Step-by-step actions to configure a free uptime monitor that catches incidents fast.
+- [Best Free Uptime Monitoring Tools (2025)](/blog/best-free-uptime-monitoring-tools) – Compare the strongest free uptime monitor platforms and when to upgrade.
+- [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) – Evaluate which free website monitor fits your stack and alerting needs.
+- [Free Website Monitoring for Developers](/blog/free-website-monitoring-for-developers) – See how engineering teams automate alerts, SLO tracking, and reporting with a free website monitor.
+


### PR DESCRIPTION
## Summary
- add a recommended resources section to every blog article to drive internal linking toward priority free uptime monitoring pages
- reinforce key search terms such as "free uptime monitor" and "free website monitor" in link anchors to support SEO targets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d6fc61032c8325b47fb11334fd9d78