### PR TITLE
Improve cross-post internal linking for monitoring guides

### DIFF
--- a/src/content/posts/ai/ai-anomaly-detection-monitoring.md
+++ b/src/content/posts/ai/ai-anomaly-detection-monitoring.md
@@ -9,7 +9,7 @@ metaDescription: "AI anomaly detection spots trouble before users bail. Learn ho
 
 # AI Detection: Catch Issues Before They Explode
 
-Traditional monitoring waits for fires. Dumb. AI predicts them. At exit1.dev, we're baking this in because devs deserve tools that think ahead.
+Traditional monitoring waits for fires. Dumb. AI predicts them. If you're still wrestling with manual thresholds, revisit our [Monitoring 101 primer](/blog/website-monitoring-101) to see exactly where classic uptime checks fall short before layering in smarter detection. At exit1.dev, we're baking this in because devs deserve tools that think ahead.
 
 ## Traditional Sucks
 
@@ -52,17 +52,17 @@ Run this. Fix before users notice.
 
 ## Real Wins
 
-E-comm site: AI caught DB bloat pre-Black Friday. Saved outage. API errors creeping? Nailed early.
+E-comm site: AI caught DB bloat pre-Black Friday. Saved outage. API errors creeping? Nailed early. Pair the models with disciplined alerting like our [real-time vs five-minute strategy](/blog/real-time-vs-5-minute-monitoring) so teams act on the signal fast.
 
 ## Our Plan at exit1.dev
 
 Phase 1: Smart baselines. Phase 2: Predictions. Phase 3: Auto-fixes.
 
-We’re starting with raw data because fancy models without clean inputs are bullshit. First pass builds a baseline from every request and response to learn what “normal” actually means. Then we feed that into models that forecast spikes or slow burns before anyone files a ticket. The endgame? When the model is dead sure your DB will choke at 3 p.m., it reroutes traffic or rolls back a bad deploy without waiting for approval. Less heroics, more uptime.
+We’re starting with raw data because fancy models without clean inputs are bullshit. First pass builds a baseline from every request and response to learn what “normal” actually means. Then we feed that into models that forecast spikes or slow burns before anyone files a ticket. The endgame? When the model is dead sure your DB will choke at 3 p.m., it reroutes traffic or rolls back a bad deploy without waiting for approval. Less heroics, more uptime. Want the human workflows to keep pace? Wire the predictions into channels built for action—our [Slack incident playbook](/blog/free-uptime-monitor-slack-integration) shows how to keep engineers aligned when the AI raises its hand.
 
 ## Do It Now
 
-Collect clean data. Review weekly. Track beyond up/down.
+Collect clean data. Review weekly. Track beyond up/down. If you need a framework for the day-to-day grind, follow the automation loop in [AI integration for monitoring](/blog/ai-integration-for-website-monitoring) to connect signals to remediation without adding chaos.
 
 ## Traps to Dodge
 

--- a/src/content/posts/ai/ai-integration-for-website-monitoring.md
+++ b/src/content/posts/ai/ai-integration-for-website-monitoring.md
@@ -9,7 +9,7 @@ metaDescription: "Plug AI into your monitoring stack to kill busywork. Get code 
 
 # AI for Monitoring: End the Manual Hell
 
-Monitoring by hand is inefficient. AI fixes it: automates, predicts, responds. Basics in our [101 guide](/blog/website-monitoring-101).
+Monitoring by hand is inefficient. AI fixes it: automates, predicts, responds. Basics in our [101 guide](/blog/website-monitoring-101). Want to see what AI does once the data flows? Pair this setup with the [anomaly detection blueprint](/blog/ai-anomaly-detection-monitoring) so you’re training models on real signal instead of noise.
 
 ## Why Bother
 
@@ -21,9 +21,9 @@ Monitoring by hand is inefficient. AI fixes it: automates, predicts, responds. B
 
 ## Setup
 
-N8N/Zapier for quick, custom for control.
+N8N/Zapier for quick, custom for control. Before wiring automations, audit your stack with the [free website monitoring tools rundown](/blog/free-website-monitoring-tools-2025) so you know which signals the AI will touch.
 
-Start with a simple webhook that fires when your site hiccups. Pipe that into a low-code tool if you're lazy or wire up a small Node service if you're picky. The AI piece slots in after the trigger: feed the payload to a model that classifies the mess, then hand the result to whatever runbook or auto-remediation script you trust. Keep the loop tight—trigger, analyze, act—so you're not building another bloated platform that dies under its own weight.
+Start with a simple webhook that fires when your site hiccups. Pipe that into a low-code tool if you're lazy or wire up a small Node service if you're picky. The AI piece slots in after the trigger: feed the payload to a model that classifies the mess, then hand the result to whatever runbook or auto-remediation script you trust. Keep the loop tight—trigger, analyze, act—so you're not building another bloated platform that dies under its own weight. Need humans looped in when the model screams? Route the verdict into our [Slack incident workflow](/blog/free-uptime-monitor-slack-integration) or the [email-first playbook](/blog/free-uptime-monitor-email-alerts) so the right team sees it instantly.
 
 ## Sources
 

--- a/src/content/posts/monitoring/free-domain-monitoring-discord-alerts.md
+++ b/src/content/posts/monitoring/free-domain-monitoring-discord-alerts.md
@@ -9,12 +9,12 @@ metaDescription: "Connect Exit1.dev’s free domain monitoring to Discord webhoo
 
 # Free Domain Monitoring with Discord Alerts: Don’t Let Your URL Slip Away
 
-Lose a domain and everything collapses—site, email, API endpoints, trust. Exit1.dev’s free domain monitoring plus Discord alerts keeps expiry warnings front and center for the people who actually care about your brand.
+Lose a domain and everything collapses—site, email, API endpoints, trust. Exit1.dev’s free domain monitoring plus Discord alerts keeps expiry warnings front and center for the people who actually care about your brand. If your ops crew camps in Slack instead, swap in the [Slack domain workflow](/blog/free-domain-monitoring-slack-alerts) so the message still lands where they work.
 
 ## Why Discord Is a Smart Domain Watchtower
 
 - **Server-wide visibility**: Pin warnings in `#status` or `#ops` so moderators and engineers know the clock is ticking.
-- **Role mentions**: Ping `@ops` and `@finance` simultaneously. The folks with the credit cards can’t pretend they didn’t see it.
+- **Role mentions**: Ping `@ops` and `@finance` simultaneously. The folks with the credit cards can’t pretend they didn’t see it. Tie those mentions to the same owners who track certificates in [our free SSL email playbook](/blog/free-ssl-monitoring-email-alerts) so renewal work stays aligned.
 - **Automation friendly**: Use bots to log alerts, open tickets, or DM the on-call engineer. Discord isn’t just memes—it’s process.
 
 ## Set Up the Integration
@@ -51,7 +51,7 @@ Mention roles, drop registrar URLs, and add staging vs. production tags. The emb
 ## Build the Renewal Muscle
 
 - **Thread the work**: First response claims the renewal. Track registrar logins, approvals, and confirmation numbers in-thread.
-- **Set reminders**: Use `/remind` or a bot to ping the thread at 7 days, 3 days, and 24 hours pre-expiry. Redundancy prevents failure.
+- **Set reminders**: Use `/remind` or a bot to ping the thread at 7 days, 3 days, and 24 hours pre-expiry. Redundancy prevents failure. Pair those reminders with your [uptime incident drills](/blog/free-uptime-monitor-checklist) so domain, SSL, and availability reviews happen together.
 - **Verify success**: After renewal, run a DNS check and post the new expiry date. Proof beats optimism.
 - **Update docs**: Link to your domain inventory or CMDB. Keep everything aligned.
 

--- a/src/content/posts/monitoring/free-domain-monitoring-slack-alerts.md
+++ b/src/content/posts/monitoring/free-domain-monitoring-slack-alerts.md
@@ -9,7 +9,7 @@ metaDescription: "Monitor domain expirations for free and wire alerts into Slack
 
 # Free Domain Monitoring with Slack Alerts: Stop Losing Domains Like Amateurs
 
-Letting a domain expire is the fastest way to light your brand on fire. Customers can’t reach you, email breaks, and some squatter buys the name before you wake up. Exit1.dev’s free domain monitoring with Slack alerts keeps the countdown in everyone’s face.
+Letting a domain expire is the fastest way to light your brand on fire. Customers can’t reach you, email breaks, and some squatter buys the name before you wake up. Exit1.dev’s free domain monitoring with Slack alerts keeps the countdown in everyone’s face. Need the same warning in other channels? Mirror it with our [Discord domain workflow](/blog/free-domain-monitoring-discord-alerts) and the [email-based SSL workflow](/blog/free-ssl-monitoring-email-alerts) so no one can claim ignorance.
 
 ## Why Slack Works for Domain Renewals
 
@@ -41,7 +41,7 @@ Make it obvious who needs to pay the invoice. Add billing links if your registra
 
 ## Lock In a Renewal Routine
 
-- **Assign an owner instantly**: First reply in the thread takes the task. No ghosting.
+- **Assign an owner instantly**: First reply in the thread takes the task. No ghosting. Document who’s on point alongside the [uptime incident checklist](/blog/free-uptime-monitor-checklist) so renewals share the same rigor as outages.
 - **Confirm payment**: Drop a screenshot or invoice number once the registrar renews the domain.
 - **Schedule sanity checks**: Use `/remind` to ping the channel seven days before expiry and again 24 hours before. Redundancy saves careers.
 - **Update documentation**: Post the new expiry date to your asset tracker or CMDB right in the thread.

--- a/src/content/posts/monitoring/free-ssl-monitoring-email-alerts.md
+++ b/src/content/posts/monitoring/free-ssl-monitoring-email-alerts.md
@@ -9,13 +9,13 @@ metaDescription: "Combine free SSL monitoring and sharp email alert workflows to
 
 # Free SSL Monitoring with Email Alerts: Renew Before Browsers Riot
 
-If your SSL certificate expires, you deserve every angry ticket that hits support. Exit1.dev’s free SSL monitoring plus ruthless email workflows makes sure you renew before browsers throw red screens at customers.
+If your SSL certificate expires, you deserve every angry ticket that hits support. Exit1.dev’s free SSL monitoring plus ruthless email workflows makes sure you renew before browsers throw red screens at customers. Prefer chat-first alerts? Mirror the same monitors into [Slack](/blog/free-ssl-monitoring-slack-alerts) or [Discord](/blog/free-ssl-monitoring-discord-alerts) so security, ops, and community teams all get the warning.
 
 ## Email Works—If You Respect It
 
 - **Universal delivery**: Legal, finance, partners—they all have email. No excuses about who got pinged.
 - **Permanent record**: Audit teams want proof you saw the warnings. Email keeps the receipts.
-- **Automation playground**: Filters, forwarding, calendar triggers—email can nag you harder than any chat bot if you configure it.
+- **Automation playground**: Filters, forwarding, calendar triggers—email can nag you harder than any chat bot if you configure it. Use the same checklists you follow for [uptime incidents](/blog/free-uptime-monitor-checklist) so SSL renewals hit the same command cadence.
 
 ## Set Up the Alerts
 
@@ -57,7 +57,7 @@ Exit1.dev gives you unlimited SSL monitors, email alerts, and status pages for f
 - Hardware-backed key storage and compliance attestations.
 - 24/7 managed rotations.
 
-If that’s not you, stick with the free stack and handle renewals like an adult.
+If that’s not you, stick with the free stack and handle renewals like an adult. While you’re at it, backstop your domains with the [Discord renewal workflow](/blog/free-domain-monitoring-discord-alerts) so DNS ownership doesn’t become the next fire drill.
 
 ## Execute Now
 

--- a/src/content/posts/monitoring/free-uptime-monitor-email-alerts.md
+++ b/src/content/posts/monitoring/free-uptime-monitor-email-alerts.md
@@ -9,13 +9,13 @@ metaDescription: "Pair a free uptime monitor with well-tuned email alerts, filte
 
 # Free Uptime Monitoring with Email Alerts: Inbox Discipline or Bust
 
-Email alerts get mocked because most teams treat the inbox like a trash heap. Clean it up and Exit1.dev’s free uptime monitor becomes a brutally reliable signal. No SMS charges. No chat noise. Just crisp alerts that land where executives, engineers, and compliance robots already live.
+Email alerts get mocked because most teams treat the inbox like a trash heap. Clean it up and Exit1.dev’s free uptime monitor becomes a brutally reliable signal. No SMS charges. No chat noise. Just crisp alerts that land where executives, engineers, and compliance robots already live. Want chat-based coverage too? Mirror the same monitors into [Slack](/blog/free-uptime-monitor-slack-integration) or [Discord](/blog/free-website-monitor-discord-integration) so nobody can claim the email slipped by.
 
 ## Why Email Still Matters (If You Stop Being Lazy)
 
 - **Universal access**: Every exec, contractor, and vendor already has email. No onboarding circus.
 - **Audit trail**: Compliance teams love archived emails. Give them receipts instead of screenshots.
-- **Filter power**: Gmail, Outlook, Fastmail—doesn’t matter. You can slice, color, auto-forward, and escalate with rules you control.
+- **Filter power**: Gmail, Outlook, Fastmail—doesn’t matter. You can slice, color, auto-forward, and escalate with rules you control. Combine filters with a [free uptime monitor checklist](/blog/free-uptime-monitor-checklist) so every alert maps to a documented response.
 
 If your inbox is a wasteland, fix that. The tool isn’t the problem; your process is.
 
@@ -66,6 +66,8 @@ Exit1.dev’s free plan gives you unlimited monitors, 30-second probes, email al
 - Regulators demand multi-channel paging.
 - You run 24/7 on-call rotations that can’t trust inboxes at 3 a.m.
 - You want integrated ticketing or ITSM workflows.
+
+If those scenarios hit, layer in the [free uptime monitor vs paid analysis](/blog/free-uptime-monitor-vs-paid) to decide when it’s worth upgrading or adding third-party paging.
 
 Otherwise, email plus discipline is enough. Do the work and stop blaming the channel.
 

--- a/src/content/posts/monitoring/free-uptime-monitor-for-saas.md
+++ b/src/content/posts/monitoring/free-uptime-monitor-for-saas.md
@@ -35,7 +35,7 @@ Downtime torches MRR and tanks trust. SaaS leaders who still fly blind are gambl
 - Role-based access with audit logs. Engineers, success, leadership—same facts, different permissions.
 - Shared incident timelines so everyone knows who did what and when.
 
-Exit1.dev ships all of this on the free tier, which is why it’s the best free uptime monitor for SaaS operators who care about reliability and runway.
+Exit1.dev ships all of this on the free tier, which is why it’s the best free uptime monitor for SaaS operators who care about reliability and runway. Need proof your comms stack can keep up? Tie those monitors to our [Slack incident recipe](/blog/free-uptime-monitor-slack-integration) and [email escalation playbook](/blog/free-uptime-monitor-email-alerts) so stakeholders hear about downtime instantly.
 
 ## Implementation Blueprint: 5-Day Rollout
 
@@ -49,9 +49,9 @@ Exit1.dev ships all of this on the free tier, which is why it’s the best free 
 - Enable SSL expiry alerts before your certificates make a fool of you.
 
 ### Day 3: Wire Up Incident Channels
-- Connect Slack, PagerDuty, email groups, maybe Opsgenie if you insist.
-- Define escalation policies for nights, weekends, and holidays.
-- Trigger a synthetic outage to prove the routing works before real users do the QA.
+- Connect Slack, PagerDuty, email groups, maybe Opsgenie if you insist. Follow the tactical steps in our [Slack integration guide](/blog/free-uptime-monitor-slack-integration) so the first alert doesn’t vanish into #random.
+- Define escalation policies for nights, weekends, and holidays. Backstop with the [email discipline workflow](/blog/free-uptime-monitor-email-alerts) if leadership still lives in their inbox.
+- Trigger a synthetic outage to prove the routing works before real users do the QA. If you serve communities, mirror the alert into [Discord status channels](/blog/free-website-monitor-discord-integration) to keep moderators in the loop.
 
 ### Day 4: Nail Customer Communication
 - Publish a branded status page that mirrors your trust center.
@@ -65,9 +65,9 @@ Exit1.dev ships all of this on the free tier, which is why it’s the best free 
 
 ## Scaling Beyond Launch
 
-- **Add synthetic user journeys** when you release new features—signups, billing, onboarding.
+- **Add synthetic user journeys** when you release new features—signups, billing, onboarding. Layer in [AI anomaly detection](/blog/ai-anomaly-detection-monitoring) once the baselines are steady so creeping failures surface early.
 - **Integrate with CI/CD** to pause deploys during active incidents.
-- **Automate postmortems** by exporting monitor history into Notion, Confluence, or Linear.
+- **Automate postmortems** by exporting monitor history into Notion, Confluence, or Linear. Then revisit the [AI automation loop](/blog/ai-integration-for-website-monitoring) to let models recommend fixes after every incident.
 
 ## Case Study: B2B SaaS Platform
 

--- a/src/content/posts/monitoring/free-uptime-monitor-slack-integration.md
+++ b/src/content/posts/monitoring/free-uptime-monitor-slack-integration.md
@@ -9,12 +9,12 @@ metaDescription: "Hook a free uptime monitor into Slack for blunt, instant alert
 
 # Free Uptime Monitor with Slack Integration: Ship Alerts Your Team Actually Sees
 
-Slack is where the real work chatter happens. If you still expect engineers to babysit inboxes, you deserve the downtime surprises you keep getting. Wire Exit1.dev’s free uptime monitor into Slack and you’ll stop guessing who saw the alert—because everyone will.
+Slack is where the real work chatter happens. If you still expect engineers to babysit inboxes, you deserve the downtime surprises you keep getting. Wire Exit1.dev’s free uptime monitor into Slack and you’ll stop guessing who saw the alert—because everyone will. Still need inbox records or community broadcasts? Pair this setup with the [email alert workflow](/blog/free-uptime-monitor-email-alerts) and the [Discord integration](/blog/free-website-monitor-discord-integration) so every stakeholder sees the hit.
 
 ## Slack Beats Pager Spam. Here’s Why.
 
 - **Visibility you can’t ignore**: Alerts drop into the same channels where code reviews and deployment debates already live. No more “missed the email” excuses.
-- **Context in one place**: Threads keep the timeline, runbooks, and status updates glued to the original alert.
+- **Context in one place**: Threads keep the timeline, runbooks, and status updates glued to the original alert. If you need long-form archives, mirror the final summary using the [email discipline playbook](/blog/free-uptime-monitor-email-alerts).
 - **Automation ready to fire**: Slack workflows, bot users, and custom reactions trigger the next move without touching a dashboard.
 
 Exit1.dev ships Slack webhooks on the free tier. No upsell. No nickel-and-diming. Plug it in and get on with building.

--- a/src/content/posts/monitoring/free-website-monitor-discord-integration.md
+++ b/src/content/posts/monitoring/free-website-monitor-discord-integration.md
@@ -9,12 +9,12 @@ metaDescription: "Connect a free website monitor to Discord webhooks for blunt, 
 
 # Free Website Monitor with Discord Integration: Tell Your Community the Truth First
 
-Discord is the town square for your product. If you let rumor threads explain downtime before you do, you’re begging for churn. Exit1.dev’s free website monitor now speaks Discord natively, so you can hit your server with the facts before someone invents a conspiracy theory.
+Discord is the town square for your product. If you let rumor threads explain downtime before you do, you’re begging for churn. Exit1.dev’s free website monitor now speaks Discord natively, so you can hit your server with the facts before someone invents a conspiracy theory. Running parallel comms for ops and leadership? Pair this with our [Slack incident channel blueprint](/blog/free-uptime-monitor-slack-integration) and [email escalation workflow](/blog/free-uptime-monitor-email-alerts) so every audience hears the same story.
 
 ## Why Discord Wins for Outage Alerts
 
 - **Community expects transparency**: Your players, customers, and moderators live in Discord. Meet them there or watch trust evaporate.
-- **Channel control**: Post critical incidents in a locked `#status` channel, drip maintenance notes into `#announcements`, and stop the chaos.
+- **Channel control**: Post critical incidents in a locked `#status` channel, drip maintenance notes into `#announcements`, and stop the chaos. For domain-specific scares, mirror the warning from [Discord domain monitoring](/blog/free-domain-monitoring-discord-alerts) so DNS renewals get the same visibility.
 - **Automation playground**: Webhook embeds let you flag roles, trigger bot workflows, and format clean status cards without hacking together a bot.
 
 The free plan includes Discord webhooks. No “enterprise tier” bait-and-switch. Use it.

--- a/src/content/posts/monitoring/free-website-monitoring-for-developers.md
+++ b/src/content/posts/monitoring/free-website-monitoring-for-developers.md
@@ -9,15 +9,15 @@ metaDescription: "Free monitoring tools for devs: CLI, API, webhooks in 2025."
 
 # Free Monitoring for Devs: Skip the UI Fluff
 
-Devs want code-friendly monitoring. Here's what fits.
+Devs want code-friendly monitoring. Here's what fits. If you’re exploring AI-driven guardrails on top of these scripts, bookmark the [automation playbook](/blog/ai-integration-for-website-monitoring) so your workflows scale with the stack.
 
 ## Why Devs Need It
 
-CLI/API automate. No point-and-click nonsense.
+CLI/API automate. No point-and-click nonsense. When you need the broader context to sell leadership, hand them our [real-time vs five-minute monitoring breakdown](/blog/real-time-vs-5-minute-monitoring) so they understand why these hooks fire frequently.
 
 ## Top Free
 
-exit1.dev: CLI-first, unlimited.
+exit1.dev: CLI-first, unlimited. Pair it with the [Slack integration guide](/blog/free-uptime-monitor-slack-integration) if you want terminal alerts mirrored straight into incident channels.
 
 ## exit1.dev Setup
 
@@ -93,6 +93,8 @@ exit1 ssl https://site.com
 exit1 ssl --details https://site.com
 ```
 
+Need deeper certificate context? Cross-check against the [SSL email renewal workflow](/blog/free-ssl-monitoring-email-alerts) so alerts trigger actual ownership.
+
 ### Response Time
 
 ```javascript
@@ -151,7 +153,7 @@ spec:
 
 ## Pitfalls/Fixes
 
-Rate limits: Batch. Bad data: Validate.
+Rate limits: Batch. Bad data: Validate. For product teams juggling customers, apply the playbook from [free uptime monitoring for SaaS](/blog/free-uptime-monitor-for-saas) so dev automation aligns with customer promises.
 
 ## Free vs Paid
 


### PR DESCRIPTION
## Summary
- connect the AI monitoring articles to foundational uptime guides and incident workflows for better context
- expand cross-channel references between the email, Slack, and Discord alert playbooks to reinforce related alerting options
- link developer- and SaaS-focused monitoring guides to supporting automation and anomaly detection resources

## Testing
- not run (content-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68d82ce0be388325a531e2b15a8c0936