### PR TITLE
Embed Exit1 badge script in footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
+import Script from 'next/script';
 import footerContent from '../content/footer.json';
 import CookieSettings from './CookieSettings';
 
@@ -80,7 +81,7 @@ const Footer = () => {
             
             {/* Peerpush Achievement Badge */}
             <div className="pt-2">
-              <a 
+              <a
                 href="https://peerpush.net/p/exit1dev"
                 target="_blank"
                 rel="noopener"
@@ -97,6 +98,11 @@ const Footer = () => {
                 />
               </a>
             </div>
+            <Script
+              src="https://exit1.dev/badge.js"
+              data-check-id="hGzAdT7mrI7tYhQ6widf"
+              strategy="lazyOnload"
+            />
           </div>
           
           {/* Navigation sections - stacked on mobile, grid on larger screens */}


### PR DESCRIPTION
## Summary
- load the Exit1 badge script via next/script in the footer
- render the script immediately below the existing Peerpush badge

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e6b77aab1083258089aef89276a209