### PR TITLE
Add SLA monitoring category with new content cluster

### DIFF
--- a/src/content/blog.json
+++ b/src/content/blog.json
@@ -13,6 +13,12 @@
       "name": "AI & Automation",
       "description": "AI-powered monitoring, automated alerts, and intelligent workflows",
       "slug": "ai"
+    },
+    {
+      "id": "sla",
+      "name": "SLA Monitoring",
+      "description": "Service-level strategies, reporting, and compliance workflows for uptime commitments",
+      "slug": "sla-monitoring"
     }
   ]
-} 
+}

--- a/src/content/posts/sla/free-sla-monitoring-checklist.md
+++ b/src/content/posts/sla/free-sla-monitoring-checklist.md
@@ -1,0 +1,61 @@
+---
+title: "Free SLA Monitoring Checklist: Weekly Rituals That Keep You Out Of Penalty Mode"
+author: "Morten Pradsgaard"
+date: "2025-02-16"
+category: "sla"
+excerpt: "Step-by-step free SLA monitoring checklist covering instrumentation, alerting, reporting, and customer communication."
+readTime: "10 min read"
+metaDescription: "Use this free SLA monitoring checklist to validate coverage, alerts, and reporting routines that protect uptime commitments."
+---
+
+# Free SLA Monitoring Checklist Your Ops Team Should Run Every Week
+
+SLA violations don’t happen because the contract changed. They happen because nobody checks the basics. This free SLA monitoring checklist is the weekly ritual that keeps engineering honest, customer success calm, and finance free from credit write-offs.
+
+## 1. Confirm Your Monitors Still Match The Contract
+
+- Review SLA targets. Any new premium tier promising 99.99%? Update the monitors.
+- Ensure every critical endpoint has a production check. Compare coverage with the [Free SLA Monitoring Tools rundown](/blog/free-sla-monitoring-tools) so gaps show up fast.
+- Validate frequency. If the SLA says five-minute response, your monitors better run more often than that.
+
+## 2. Verify Alert Routing End-To-End
+
+- Trigger a synthetic failure on your top endpoint.
+- Confirm alerts hit Slack, email, and SMS. Use the playbooks in [Free Uptime Monitor Email Alerts](/blog/free-uptime-monitor-email-alerts) if notifications look stale.
+- Inspect escalation. Does the secondary on-call respond? If not, fix the rotation before legal notices.
+
+## 3. Inspect Error Budgets And Incident Timelines
+
+- Pull uptime and latency stats from Exit1.dev dashboards. Compare them against your SLA thresholds.
+- Look at the past week’s incidents. Were response and resolution inside contract windows?
+- Update incident reports using the [postmortem template kit](/blog/incident-postmortem-templates-with-exit1). Share with GTM teams before customers ask.
+
+## 4. Refresh Customer-Facing Surfaces
+
+- Check your status page copy. If it’s outdated, rewrite it now.
+- Publish timeline updates for ongoing incidents. Even “still investigating” beats silence.
+- Link to deep dives like the [Free SLA Monitoring Guide](/blog/free-sla-monitoring-guide) when customers want to know how you track reliability.
+
+## 5. Audit Integrations And Automation
+
+- Confirm webhooks still fire into ticketing, PagerDuty, and whatever glue code you run.
+- Test any no-code automation. If it breaks silently, your SLA is toast.
+- Review logs for failed exports. Monthly SLA reports should be on autopilot through the [SLA reporting stack](/blog/sla-reporting-free-uptime-stack).
+
+## 6. Share The Metrics Internally
+
+- Send a quick digest to leadership. Wins, risks, next steps.
+- Push uptime graphs to customer success so renewals conversations stay confident.
+- Drop takeaways in the company all-hands. Reliability is everyone’s job, not just ops.
+
+## Bonus: Quarterly Deep Clean
+
+Beyond the weekly loop, run a deeper audit every quarter:
+
+- Compare tool performance using the [Free SLA Monitoring Strategy guide](/blog/free-sla-monitoring-strategy) you’re reading now.
+- Retire legacy monitors that trigger false alarms.
+- Load test failover paths so you’re not improvising during a real outage.
+
+## Run The Checklist, Keep The Credits
+
+Free SLA monitoring thrives on discipline. This checklist keeps the discipline tight. Run it weekly, automate the evidence, and share the results. Customers stay informed, auditors stay quiet, and you stay out of the penalty box.

--- a/src/content/posts/sla/free-sla-monitoring-for-msps.md
+++ b/src/content/posts/sla/free-sla-monitoring-for-msps.md
@@ -1,0 +1,64 @@
+---
+title: "Free SLA Monitoring For MSPs: Protect Margins And Keep Clients Loyal"
+author: "Morten Pradsgaard"
+date: "2025-02-17"
+category: "sla"
+excerpt: "How managed service providers deliver free SLA monitoring across client fleets without burning margins or headcount."
+readTime: "11 min read"
+metaDescription: "Learn how MSPs can roll out free SLA monitoring across client environments with standardized playbooks, tooling, and reporting."
+---
+
+# Free SLA Monitoring For MSPs Who Refuse To Eat Penalty Fees
+
+Managed service providers live and die by SLAs. Miss them and you’re writing credits, losing retainers, and fielding angry QBRs. The fix isn’t more headcount. It’s a free SLA monitoring setup that scales across every client tenant without blowing the budget.
+
+## Standardize The Baseline Stack
+
+MSPs can’t babysit bespoke tooling for each client. Build a baseline:
+
+- **Exit1.dev monitors** across HTTP, API, and synthetic journeys. Unlimited monitors mean you can duplicate coverage per client without a pricing migraine.
+- **Shared alert routing** via centralized Slack, Teams, or email channels. Clone the [Slack integration workflow](/blog/free-uptime-monitor-slack-integration) per client workspace.
+- **Status pages** branded for each customer. Use the same automation to publish updates across the fleet.
+
+This keeps the free SLA monitoring experience consistent while still delivering the white-glove feel clients expect.
+
+## Automate Onboarding And Audits
+
+Stop rolling installs by hand. Create a playbook:
+
+1. Import the client’s SLA clauses into your template.
+2. Run the [Free SLA Monitoring Checklist](/blog/free-sla-monitoring-checklist) during kickoff.
+3. Clone monitor groups, alert policies, and reporting exports inside Exit1.dev.
+4. Schedule quarterly reviews and plug them into your PSA or ticketing tool.
+
+The result? Every new client hits compliance in under a day, and the ops team isn’t context switching between ten dashboards.
+
+## Deliver Reporting Clients Actually Read
+
+Clients don’t want raw logs. They want proof you met the SLA:
+
+- Send branded monthly summaries powered by the [SLA reporting toolkit](/blog/sla-reporting-free-uptime-stack).
+- Attach incident timelines generated from the [postmortem templates](/blog/incident-postmortem-templates-with-exit1). Keep them plain language.
+- During QBRs, reference the flagship [Free SLA Monitoring Tools breakdown](/blog/free-sla-monitoring-tools) to show why your stack beats DIY setups.
+
+## Monetize Premium Layers Without Breaking The Free Core
+
+Offer add-ons without ditching free SLA monitoring:
+
+- **Advanced analytics** – Bundle log correlation or RUM as premium tiers.
+- **Compliance reporting** – Package SOC 2 or HIPAA evidence collection as an upgrade.
+- **24/7 response** – Use free tooling to handle detection, then price the human escalation separately.
+
+This keeps your margins intact while clients feel like they’re getting bespoke care.
+
+## Operational Guardrails To Protect Margins
+
+- **Templatize everything** – From alert copy to maintenance notices. Reuse or die.
+- **Centralize on-call** – One rotation covering multiple clients beats ten micro-teams burning out.
+- **Review profitability** – Compare SLA effort to revenue monthly. If a client drags down the average, renegotiate or fire them.
+
+## Free SLA Monitoring Is Your Competitive Edge
+
+MSPs that master free SLA monitoring win deals by proving reliability without passing costs to clients. Standardize the stack, automate onboarding, and deliver reports that tell a clear story. Do that and you defend margins, renew contracts, and keep your reputation untouchable.
+
+Ready to tighten the playbook further? Pair this guide with the flagship [Free SLA Monitoring Strategy](/blog/free-sla-monitoring-strategy) to align sales promises with operational reality.

--- a/src/content/posts/sla/free-sla-monitoring-reporting-playbook.md
+++ b/src/content/posts/sla/free-sla-monitoring-reporting-playbook.md
@@ -1,0 +1,77 @@
+---
+title: "Free SLA Monitoring Reporting Playbook: Ship Audit-Ready Evidence On Demand"
+author: "Morten Pradsgaard"
+date: "2025-02-18"
+category: "sla"
+excerpt: "Reporting framework for free SLA monitoring teams that need executive dashboards, customer updates, and legal-ready evidence."
+readTime: "13 min read"
+metaDescription: "Build a free SLA monitoring reporting playbook covering dashboards, exports, and communications that satisfy auditors and clients."
+---
+
+# Free SLA Monitoring Reporting Playbook That Wins Trust Every Time
+
+You can hit every uptime target and still lose the customer if you can’t prove it. Reporting is the difference between trust and churn. This playbook shows how free SLA monitoring tools deliver audit-ready evidence without paying for an enterprise analytics suite.
+
+## Step 1: Define The Audiences
+
+Reporting fails when you shove one dashboard at everyone. Split the audiences:
+
+- **Executives** want trend lines and risk signals.
+- **Customer success** needs clear data for renewals.
+- **Customers** want transparent uptime proof.
+- **Auditors** demand traceable logs and documented processes.
+
+Write the deliverables for each before you touch a tool.
+
+## Step 2: Build Real-Time Dashboards For Operators And Execs
+
+Exit1.dev status pages and internal dashboards cover both speed and clarity:
+
+- **Operational view** – latency, uptime, incident counts. Share it with leadership. Add annotations when you ship fixes.
+- **Executive view** – Rolling 30-day and 90-day uptime, error budget burn, top risks. Layer commentary so they understand the context, not just the numbers.
+
+Need inspiration? Cross-reference the [Free SLA Monitoring Strategy](/blog/free-sla-monitoring-strategy) for how to map SLA clauses into meaningful visuals.
+
+## Step 3: Automate Scheduled Reports
+
+No one wants to copy-paste charts at month-end. Automate it:
+
+- Schedule CSV or PDF exports directly from Exit1.dev.
+- Pipe data into Sheets or Notion if leadership wants commentary alongside metrics.
+- Compare the results against the templates in [SLA reporting stack guide](/blog/sla-reporting-free-uptime-stack) so every report looks consistent.
+
+## Step 4: Publish Incident Narratives Fast
+
+When downtime hits, your story matters as much as the fix:
+
+- Post updates to your status page within minutes. Use the tone from [Free SLA Monitoring Tools](/blog/free-sla-monitoring-tools) — factual, zero fluff.
+- Follow up with a postmortem using the [incident template library](/blog/incident-postmortem-templates-with-exit1). Include impact, root cause, and remediation.
+- Link to relevant docs or [Free SLA Monitoring Guide](/blog/free-sla-monitoring-guide) so customers see the broader process.
+
+## Step 5: Package Evidence For Auditors And Enterprise Deals
+
+Auditors want proof you followed the process, not marketing copy.
+
+- Store monitor configurations, alert logs, and incident reports in a version-controlled repo.
+- Document the weekly routine using the [Free SLA Monitoring Checklist](/blog/free-sla-monitoring-checklist) so compliance reviewers see discipline.
+- Share access securely during audits or enterprise evaluations. Let them browse evidence instead of staging a fire drill.
+
+## Step 6: Close The Loop With Customers
+
+Reporting isn’t finished when you send a PDF. Follow up:
+
+- Host quarterly reviews. Walk through wins, misses, and upcoming improvements.
+- Invite feedback on the report format. Adapt without sacrificing clarity.
+- Reinforce the narrative that free SLA monitoring works because the process is tight, not because you cheaped out on tooling.
+
+## Bonus: Turn Reporting Into A Marketing Weapon
+
+You’re already doing the work. Repurpose it:
+
+- Create anonymized case studies pulling from SLA successes.
+- Publish highlights on your blog to reinforce expertise. Link back to cornerstone pieces like the [Free SLA Monitoring Strategy](/blog/free-sla-monitoring-strategy).
+- Use the data in sales decks to win over prospects terrified of switching vendors.
+
+## Free SLA Monitoring Reporting That Actually Impresses
+
+When reporting is automated, audience-aware, and transparent, you become the vendor everyone trusts. Free SLA monitoring gives you the data. This playbook gives you the discipline. Execute it and every audit, QBR, and renewal conversation becomes a victory lap.

--- a/src/content/posts/sla/free-sla-monitoring-strategy.md
+++ b/src/content/posts/sla/free-sla-monitoring-strategy.md
@@ -1,0 +1,79 @@
+---
+title: "Free SLA Monitoring Strategy: Nail Commitments Without Paying Enterprise Tax"
+author: "Morten Pradsgaard"
+date: "2025-02-15"
+category: "sla"
+excerpt: "Blueprint for building a free SLA monitoring strategy that satisfies legal, ops, and customer success without bloated software."
+readTime: "12 min read"
+metaDescription: "Design a free SLA monitoring strategy that covers uptime targets, incident response, and reporting using lightweight tooling."
+---
+
+# Free SLA Monitoring Strategy That Actually Defends Your SLA Numbers
+
+Everyone parrots SLAs. Few can prove they honor them. Free SLA monitoring is how you ship that proof without funding a bloated platform. This strategy walks through contracts, instrumentation, alerting, and reporting with tools that keep you compliant and nimble.
+
+## Start With The SLA Clauses, Not The Tool Wishlist
+
+Most teams jump straight into tool shopping. Wrong order. Pull the signed SLA and highlight:
+
+- Uptime targets (99.9%, 99.95%, whatever legal promised during the sales call).
+- Response commitments (15-minute acknowledgement? Four-hour resolution?).
+- Reporting cadence (monthly summaries, on-demand dashboards, audit trails).
+- Credit triggers (how fast penalties land if you miss targets).
+
+Now map each clause to instrumentation. That keeps your free SLA monitoring stack lean and honest.
+
+## Instrument Every Customer-Facing Promise
+
+If you claimed reliability on a homepage, monitor it. Minimum viable coverage:
+
+1. **Transactional flows** – Checkout, signup, auth. Synthetic journeys in [Exit1.dev](https://exit1.dev) cover this without a dev babysitting Selenium.
+2. **Core APIs** – REST, GraphQL, gRPC. Pair request monitors with the [Free SLA Monitoring Tools comparison](/blog/free-sla-monitoring-tools) to see which free checks match your protocol.
+3. **Third-party dependencies** – Payment, email, auth. Don’t hide behind “not our fault.” Monitor them and show you escalated fast.
+4. **Status surfaces** – Status pages, support widgets, public uptime badges. Keep them updated or your SLA is a lie.
+
+## Alerts Must Match Legal Timelines
+
+Response time commitments are meaningless if alerts lag. Wire alerts like you mean it:
+
+- **Primary channel**: Use [Slack incident playbooks](/blog/free-uptime-monitor-slack-integration) to hit the right team instantly.
+- **Fallback**: Email and SMS via [Free Uptime Monitor Email Alerts](/blog/free-uptime-monitor-email-alerts) for when Slack is the outage.
+- **Escalation**: Webhooks into PagerDuty or Opsgenie if response times are under an hour.
+
+Test them quarterly. If the alert wakes the wrong person, your SLA is smoke.
+
+## Reporting Without Enterprise Shelfware
+
+Lawyers and customer success want receipts. Give them:
+
+- **Real-time dashboards** – Exit1.dev status pages cover this. Lightweight, branded, always accurate.
+- **Monthly SLA packs** – Automate exports using the [SLA reporting stack](/blog/sla-reporting-free-uptime-stack) so finance stops chasing PDFs.
+- **Incident postmortems** – Use the [Incident template library](/blog/incident-postmortem-templates-with-exit1) to show corrective action.
+
+Free tooling makes this repeatable if you automate the exports and lock the workflow.
+
+## Operational Habits That Keep The SLA Honest
+
+1. **Run chaos drills** – Break something on purpose every quarter. Verify alerts, runbooks, and reports hold up.
+2. **Audit monitors** – Prune dead checks. Add new endpoints after every sprint review. Free doesn’t mean sloppy.
+3. **Share the metrics** – Push uptime graphs into GTM and customer success decks. Make SLA health a company KPI.
+
+## When To Pay (And When Not To)
+
+Pay when:
+
+- You need compliance certifications bundled (SOC 2, HIPAA, etc.).
+- Synthetic monitoring volume explodes beyond what free tiers allow.
+- You require deep log correlation in one pane of glass.
+
+Hold the line on free when:
+
+- You’re still chasing basic uptime promises.
+- Teams respond to incidents within SLA windows already.
+- Reports satisfy customers and auditors.
+
+## Free SLA Monitoring: Your Foundation For Expansion
+
+Free SLA monitoring isn’t a consolation prize. It’s a disciplined practice that proves your promises before you buy enterprise extras. Start with contract clauses, map the coverage, automate alerts, and show receipts. That’s how you defend uptime commitments and keep the logo wall growing without torching the budget.
+
+Need tooling examples? Pair this strategy with the existing [Free SLA Monitoring Guide](/blog/free-sla-monitoring-guide) to kick off implementation today.


### PR DESCRIPTION
## Summary
- add a dedicated SLA Monitoring category to the blog taxonomy
- publish four new Free SLA Monitoring articles to deepen topical authority and cross-link existing guides

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_690d32a958148325bb84f5668e7519e4