### PR TITLE
Add incident management blog category with new content

### DIFF
--- a/src/content/blog.json
+++ b/src/content/blog.json
@@ -19,6 +19,12 @@
       "name": "SLA Monitoring",
       "description": "Service-level strategies, reporting, and compliance workflows for uptime commitments",
       "slug": "sla-monitoring"
+    },
+    {
+      "id": "incident",
+      "name": "Incident Management",
+      "description": "Response playbooks, tooling, and cultural shifts for fast, honest incident resolution",
+      "slug": "incident-management"
     }
   ]
 }

--- a/src/content/posts/incident-management/free-incident-management-runbook.md
+++ b/src/content/posts/incident-management/free-incident-management-runbook.md
@@ -1,0 +1,52 @@
+---
+title: "The Free Incident Management Runbook Your Team Will Actually Use"
+author: "Morten Pradsgaard"
+category: "incident"
+excerpt: "Codify incident response without bureaucratic bloat. This exit1.dev-powered runbook keeps teams fast, honest, and unblocked."
+date: "2025-03-09"
+metaDescription: "Create a free incident management runbook backed by exit1.dev monitoring. Define triggers, roles, and recovery steps without paying for enterprise tooling."
+---
+
+# The Free Incident Management Runbook Your Team Will Actually Use
+
+Runbooks rot when they’re verbose and detached from the tools you actually touch during an outage. This free incident management runbook keeps it stripped down to triggers, actions, and owners—all anchored on exit1.dev monitoring data.
+
+## Trigger table: decide in seconds
+
+Document the obvious failure modes and the first move. Keep it in a simple table or Notion doc. Start with these exit1.dev signal categories:
+
+| Trigger | Action | Owner |
+| --- | --- | --- |
+| 2 consecutive 500s on checkout API | Flip traffic to secondary region runbook | Ops lead |
+| Latency spikes >1s on auth | Roll back the last deployment | Engineering on-call |
+| SSL expiry warning | Follow [free SSL monitoring alerts guide](/blog/ssl-certificate-monitoring-alerts-made-easy-and-why-it-matters) | Platform lead |
+| Third-party dependency down | Enable feature flag failsafe | Product engineer |
+
+You can add nuance later. Right now you’re aiming for a fast response, not legalese.
+
+## Response timeline: own the first 15 minutes
+
+The first 15 minutes decide whether you drown in chaos or regain control. Bake this flow into the runbook:
+
+1. **Minute 0–1**: exit1.dev alert hits Slack and email. Incident commander acknowledges.
+2. **Minute 2–4**: Ops lead validates scope via the dashboard’s regional breakdown.
+3. **Minute 5–7**: Post initial customer update using the template from the [free uptime monitor email alerts guide](/blog/free-uptime-monitor-email-alerts).
+4. **Minute 8–15**: Execute mitigation, log each step in the incident channel, and loop the status page.
+
+## Evidence capture: zero guesswork postmortems
+
+If you don’t capture evidence in real time, your postmortem becomes fiction. exit1.dev helps you grab:
+
+- **Alert history exports** – timestamped detection and recovery.
+- **Log downloads** – HTTP status codes, regional impacts.
+- **Analytics screenshots** – uptime and latency charts for exec summaries.
+
+Store them in the incident ticket immediately. Future you will thank present you when you revisit the event.
+
+## Runbook hygiene: iterate without ceremony
+
+Review the runbook monthly. Compare it with real incidents and adjust. Fold in lessons from resources like the [multi-region performance tuning guide](/blog/multi-region-performance-tuning-global-probes) to sharpen mitigation steps. Free incident management thrives on ruthless iteration, not bigger PDFs.
+
+## Send the signal: you take resilience seriously
+
+Runbooks aren’t corporate theater. They tell your team and your customers you’re ready for impact. exit1.dev gives you the live data to make the runbook work. Document the steps, rehearse them, and you’ll ship with the confidence that when things break—and they will—you’re ready to slam the door on downtime.

--- a/src/content/posts/incident-management/free-incident-management-toolkit.md
+++ b/src/content/posts/incident-management/free-incident-management-toolkit.md
@@ -1,0 +1,55 @@
+---
+title: "Free Incident Management Toolkit: Alerts, Automations, and Accountability"
+author: "Morten Pradsgaard"
+category: "incident"
+excerpt: "Assemble a free incident management toolkit powered by exit1.dev. Ship faster recoveries without begging finance for budget."
+date: "2025-03-09"
+metaDescription: "Assemble a free incident management toolkit using exit1.dev. Combine alerts, automations, and accountability workflows to run serious incident response without paying enterprise fees."
+---
+
+# Free Incident Management Toolkit: Alerts, Automations, and Accountability
+
+You don’t need to sign another enterprise contract to handle outages like an adult. This free incident management toolkit shows how to wire exit1.dev into the rest of your stack so you get ruthless visibility, clear ownership, and zero excuses.
+
+## Monitoring and alerting: the heartbeat
+
+Start with the obvious: exit1.dev monitors everywhere that matters. Configure:
+
+- **HTTP checks** for every public-facing endpoint.
+- **Cron monitors** for data pipelines and background jobs (pair with the [cron job monitoring guide](/blog/cron-job-worker-monitoring-http-hooks)).
+- **SSL and domain monitors** to avoid self-inflicted downtime.
+
+Route alerts into Slack and email. Use the webhook integration to trigger automation platforms like n8n or Zapier to open tickets the second an incident begins.
+
+## Automation: remove toil, not judgment
+
+Automation should clear the runway for human decisions. Combine exit1.dev with:
+
+- **GitHub Actions** that auto-roll back when a monitor fails right after a deploy.
+- **Status page updates** via API calls triggered by exit1.dev webhooks.
+- **Incident ticket templates** in Linear or Jira so every event captures the same metadata.
+
+Tie the automations back to the [free uptime monitor SLA reporting stack](/blog/sla-reporting-free-uptime-stack) so stakeholders get consistent metrics.
+
+## Communication: clarity beats spin
+
+Customer trust evaporates faster than uptime. Use this workflow:
+
+1. exit1.dev alert fires and posts to Slack.
+2. The comms lead copies the pre-written template from the [free uptime monitor email alerts guide](/blog/free-uptime-monitor-email-alerts).
+3. Update the status page and pin the latest state in the incident channel.
+
+Keep the updates short, timestamped, and free of speculation. Your audience cares about impact and recovery ETA, not your feelings.
+
+## Post-incident accountability: receipts or it didn’t happen
+
+After recovery, export exit1.dev logs and attach them to the incident ticket. Review them in your retro alongside:
+
+- The [incident postmortem templates](/blog/incident-postmortem-templates-with-exit1) for structured follow-up.
+- The [best free website monitoring tool comparison](/blog/best-free-website-monitoring-tool-2025) to ensure your stack stays sharp.
+
+Assign owners to every action item and set due dates on the spot. If a task doesn’t have an owner, it’s fantasy.
+
+## The result: enterprise-grade resilience without enterprise invoices
+
+This toolkit isn’t theoretical. It’s how lean teams ship reliable software while keeping finance off their backs. exit1.dev is the spine. Plug in the right automations, keep communication brutally honest, and you’ll outrun teams burning cash on bloated incident suites.

--- a/src/content/posts/incident-management/free-incident-management-war-room.md
+++ b/src/content/posts/incident-management/free-incident-management-war-room.md
@@ -1,0 +1,50 @@
+---
+title: "Run a Free Incident Management War Room that Actually Resolves Things"
+author: "Morten Pradsgaard"
+category: "incident"
+excerpt: "Turn exit1.dev alerts into a disciplined war room. Crisp roles, async updates, and a bias toward recovery over chatter."
+date: "2025-03-09"
+metaDescription: "Build a no-cost incident management war room using exit1.dev. Structure roles, communication, and recovery workflows without paying for enterprise incident software."
+---
+
+# Run a Free Incident Management War Room that Actually Resolves Things
+
+Most “war rooms” devolve into noise. You don’t need another overpriced dashboard; you need structure. Here’s how to run a free incident management war room with exit1.dev as the backbone.
+
+## Set roles before the outage
+
+A war room collapses when everyone freelances. Assign these roles ahead of time:
+
+- **Incident commander**: Keeps the room focused and decides when to escalate.
+- **Comms lead**: Posts updates to customers, execs, and the status page.
+- **Ops lead**: Owns the technical mitigation.
+
+Document the roster right next to your monitors. If you still haven’t built that roster, start with the [free uptime monitor for SaaS guide](/blog/free-uptime-monitor-for-saas).
+
+## Use exit1.dev as the single source of truth
+
+When exit1.dev fires, the incident commander shares the alert message verbatim. No reinterpretation, no delay. Then they pin three links in the channel:
+
+1. The failing monitor in exit1.dev.
+2. The real-time latency dashboard.
+3. The runbook page (even if it’s a Notion doc).
+
+If you’re still tempted to open another tool, read the [Pingdom alternative breakdown](/blog/pingdom-alternative-free-unlimited-monitoring) and remind yourself why you switched.
+
+## Keep communication brutal and timestamped
+
+Every update must answer three questions: What changed? What’s next? Who owns it? exit1.dev already tracks the technical timeline, so you’re reporting human intent. Stick to a format like:
+
+```
+13:02 UTC – Ops lead – rolled back API deploy 812. Expect recovery in 5 minutes.
+```
+
+If nothing changes, say so every 10 minutes. Silence breeds executive drive-bys and customer churn.
+
+## Don’t close until you can explain the failure
+
+The war room ends when the incident commander can explain root cause and recovery steps. Use the [incident postmortem template](/blog/incident-postmortem-templates-with-exit1) as the exit checklist. If the explanation is mushy, you’re not done.
+
+## Lock in the learnings instantly
+
+Before people scatter, assign follow-up tasks straight from the war room log. exit1.dev’s alert history plus Slack timestamps make it trivial. Drop those tasks into your issue tracker, link back to the incident channel, and schedule a 24-hour retro. That’s how free incident management stays sharp instead of sliding back into chaos.

--- a/src/content/posts/incident-management/free-incident-management-with-exit1.md
+++ b/src/content/posts/incident-management/free-incident-management-with-exit1.md
@@ -1,0 +1,46 @@
+---
+title: "Free Incident Management with exit1.dev: The Pragmatic Stack"
+author: "Morten Pradsgaard"
+category: "incident"
+excerpt: "Run disciplined, free incident management without adding cruft. exit1.dev gives you alerts, evidence, and collaboration glue."
+date: "2025-03-09"
+metaDescription: "Build a free incident management practice with exit1.dev. Combine real-time alerts, evidence, and collaboration workflows without paying enterprise prices."
+---
+
+# Free Incident Management with exit1.dev: The Pragmatic Stack
+
+Incident management is supposed to be ruthless about downtime, not budgets. exit1.dev gives you the critical pieces—detection, context, communication—without bloated enterprise tooling. Here’s how to stand up a free incident management practice that actually works.
+
+## Anchor everything in precise detection
+
+If your monitors are sloppy, your incident response will be sloppy. Configure exit1.dev uptime checks across core API endpoints, login flows, and external dependencies. Use:
+
+- **1-minute probes** for customer-facing surfaces.
+- **Synthetic transactions** on checkout and onboarding flows.
+- **Regional redundancy** so you know if the failure is local or global.
+
+Pair these with the [free uptime monitor checklist](/blog/free-uptime-monitor-checklist) to make sure coverage is complete.
+
+## Make alerts impossible to ignore
+
+Free incident management fails when alerts arrive late or disappear in inbox sludge. exit1.dev already pumps notifications to Slack, email, Discord, and webhooks. Wire the webhooks into PagerDuty or Opsgenie if you already use them. Otherwise, drive Slack first responders with:
+
+1. A dedicated `#incident-response` channel.
+2. Exit1.dev webhook posts that tag the on-call role.
+3. A pinned playbook linking to [real-time vs 5-minute monitoring](/blog/real-time-vs-5-minute-monitoring) so nobody debates polling frequency mid-incident.
+
+## Keep the war room async-friendly
+
+Not everyone can hop on a Zoom immediately. Log every update in the incident channel. exit1.dev’s alert history gives a timeline with zero effort. Drop charts and logs straight from the dashboard so product and support stay in sync.
+
+- Snapshot the response-time graphs the moment the incident starts.
+- Paste log exports with timestamps for engineers jumping in late.
+- Quote customer-impact details pulled from [incident postmortem templates](/blog/incident-postmortem-templates-with-exit1).
+
+## Automate the close-out, not the thinking
+
+When the smoke clears, use exit1.dev to export the incident window. Attach it to your postmortem doc and assign follow-ups. The platform keeps seven days of detailed logs on the free plan, so download them before they roll off. If you need a deeper audit trail, push the data into a warehouse using the [Exit1 logs to warehouse guide](/blog/exit1-logs-to-warehouse-csv-excel).
+
+## The uncompromising baseline
+
+Free incident management isn’t about duct-taping tools. It’s about demanding observability, alerting, and accountability without surrendering the budget. exit1.dev hands you that baseline. Stop waiting for a procurement cycle—set up the monitors today, wire the alerts, and run your next incident with receipts instead of guesswork.


### PR DESCRIPTION
## Summary
- add an incident management blog category for free response workflows
- publish four keyword-focused posts to target "Free Incident Management"
- weave internal links to existing uptime, SLA, and postmortem resources

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_690d3af8d91c8325b7d3113b0df636b2