### PR TITLE
Add infrastructure monitoring blog category and content

### DIFF
--- a/src/content/blog.json
+++ b/src/content/blog.json
@@ -25,6 +25,12 @@
       "name": "Incident Management",
       "description": "Response playbooks, tooling, and cultural shifts for fast, honest incident resolution",
       "slug": "incident-management"
+    },
+    {
+      "id": "infrastructure-monitoring",
+      "name": "Server & Infrastructure Monitoring",
+      "description": "Hybrid cloud uptime, infrastructure visibility, and free server monitoring tactics",
+      "slug": "infrastructure-monitoring"
     }
   ]
 }

--- a/src/content/posts/infrastructure-monitoring/free-infrastructure-monitoring-stack.md
+++ b/src/content/posts/infrastructure-monitoring/free-infrastructure-monitoring-stack.md
@@ -1,0 +1,55 @@
+---
+title: "Build a Free Infrastructure Monitoring Stack with Exit1.dev"
+author: "Morten Pradsgaard"
+date: "2025-02-16"
+category: "infrastructure-monitoring"
+excerpt: "Design a no-budget server monitoring stack that still gives full observability. Exit1.dev plus proven open-source tools."
+readTime: "7 min read"
+metaDescription: "How to build a free infrastructure monitoring stack with Exit1.dev, open-source collectors, and ruthless alerting discipline."
+---
+
+# Build a Free Infrastructure Monitoring Stack that Doesn't Suck
+
+You do not need Datadog invoices to keep infrastructure honest. Pair Exit1.dev with a few lean open-source tools and you have real coverage without the burn.
+
+## Core Monitoring Loop
+
+1. **Exit1.dev uptime monitors** hit every server-facing endpoint every minute. That is your heartbeat.
+2. **Prometheus node exporters** feed system metrics into a local store. Snapshot critical metrics and send webhooks to Exit1.dev for threshold breaches.
+3. **Grafana dashboards** stitch the story together for humans. Embed Exit1.dev status widgets right in those dashboards.
+
+## Alert Routing Without Noise
+
+Hook the monitors into the channels where ops lives:
+
+- Slack via the [free Slack integration](/blog/monitoring/free-uptime-monitor-slack-integration) for day shift.
+- Email digests for execs who only want summaries.
+- PagerDuty through the [automation guide](/blog/monitoring/pagerduty-opsgenie-webhook-automation-exit1) for escalation.
+
+## Server Coverage Checklist
+
+Cover every tier with a free sensor:
+
+- HTTP checks for APIs, CDNs, web apps.
+- TCP checks for databases and queues using simple netcat scripts wrapped in Exit1.dev custom monitors.
+- Cron monitors for nightly jobs, using the [cron job monitoring blueprint](/blog/monitoring/cron-job-worker-monitoring-http-hooks).
+
+## Infrastructure Change Audits
+
+Every deploy should update monitors. Pipe your CI/CD into Exit1.dev via webhooks so new services immediately register for uptime checks. Pair this with infrastructure-as-code tagging, then expose environment metadata in your [website monitoring best practices](/blog/monitoring/website-monitoring-best-practices-2025) review.
+
+## Incident Feedback Loop
+
+When things blow up, log it:
+
+- Use Exit1.dev incident timelines to capture the raw timeline.
+- Publish a transparent recap using the [postmortem templates](/blog/monitoring/incident-postmortem-templates-with-exit1).
+- Feed lessons back into Terraform or Ansible so the fix survives the next deploy.
+
+## Why Exit1.dev Wins for Free Infrastructure Monitoring
+
+- Unlimited checks, one-minute intervals, no card.
+- Infrastructure tags match the same taxonomy as your [free uptime monitor checklist](/blog/monitoring/free-uptime-monitor-checklist).
+- Dead simple onboarding for agencies and MSPs who need server monitoring yesterday.
+
+Stop buying shelfware. Ship this stack, own your infrastructure, and keep the cash for things that actually differentiate your product.

--- a/src/content/posts/infrastructure-monitoring/free-infrastructure-monitoring-tools-comparison-2025.md
+++ b/src/content/posts/infrastructure-monitoring/free-infrastructure-monitoring-tools-comparison-2025.md
@@ -1,0 +1,47 @@
+---
+title: "Free Infrastructure Monitoring Tools 2025: Exit1.dev vs. The Rest"
+author: "Morten Pradsgaard"
+date: "2025-02-17"
+category: "infrastructure-monitoring"
+excerpt: "Compare free server and infrastructure monitoring options. Learn why Exit1.dev outruns legacy free tiers in 2025."
+readTime: "8 min read"
+metaDescription: "Free infrastructure monitoring tools comparison 2025: Exit1.dev vs Prometheus, Zabbix, Netdata, and cloud freebies."
+---
+
+# Free Infrastructure Monitoring Tools 2025
+
+Everyone claims "free" server monitoring. Most bolt on strings. Here is the blunt breakdown.
+
+## Exit1.dev: Unlimited by Default
+
+- **Scope:** HTTP, cron, SSL, domain monitoring, incident timelines.
+- **Pricing:** Actually free. Unlimited monitors, one-minute intervals, no credit card.
+- **Why it matters:** Infrastructure teams ship faster when they do not babysit license limits. Pair it with the [free uptime monitor checklist](/blog/monitoring/free-uptime-monitor-checklist) and you cover both public and internal services.
+
+## Prometheus + Grafana: Metrics Engine, Not Alerts Out of the Box
+
+- **Strengths:** Rich metrics collection, huge exporter ecosystem.
+- **Weaknesses:** No turnkey alerts, no uptime checks. You must wire Alertmanager, hosts, and notifications manually.
+- **Fix:** Trigger webhooks into Exit1.dev to reuse the alerting and incident stack described in the [infrastructure monitoring stack guide](/blog/infrastructure-monitoring/free-infrastructure-monitoring-stack).
+
+## Zabbix: Heavyweight Legacy
+
+- **Strengths:** Deep protocol coverage, SNMP heritage.
+- **Weaknesses:** Painful UI, self-hosted burden, alerting needs babysitting.
+- **Fix:** Keep Zabbix for network edge cases but forward incidents to Exit1.dev so you consolidate real-time alerts in Slack and PagerDuty.
+
+## Netdata: Gorgeous Dashboards, Narrow Scope
+
+- **Strengths:** Automatic Linux agent, instant dashboards.
+- **Weaknesses:** No global check network, limited alert routing.
+- **Fix:** Treat Netdata as local troubleshooting. Exit1.dev handles customer-facing uptime and SLA evidence, as detailed in the [SLA reporting stack](/blog/monitoring/sla-reporting-free-uptime-stack).
+
+## Cloud Provider Freebies (AWS CloudWatch, Azure Monitor, GCP Cloud Monitoring)
+
+- **Strengths:** Native metrics, integrations with managed services.
+- **Weaknesses:** Sampling delays, regional lock-in, surprise bills when you cross thresholds.
+- **Fix:** Mirror key endpoints inside Exit1.dev. Use CloudWatch for deep metrics and Exit1.dev to guarantee external perspective and fast alerts.
+
+## Final Verdict
+
+If you want free infrastructure monitoring that still punches, Exit1.dev is the backbone. Layer specialized tools where they shine, but anchor uptime, SLA reporting, and alert routing on a platform built for speed. Anything else is a science project.

--- a/src/content/posts/infrastructure-monitoring/free-server-monitoring-checklist-2025.md
+++ b/src/content/posts/infrastructure-monitoring/free-server-monitoring-checklist-2025.md
@@ -1,0 +1,61 @@
+---
+title: "Free Server Monitoring Checklist 2025: No-Compromise Infrastructure Visibility"
+author: "Morten Pradsgaard"
+date: "2025-02-15"
+category: "infrastructure-monitoring"
+excerpt: "Build a no-cost infrastructure monitoring checklist that actually keeps servers online. Step-by-step with Exit1.dev."
+readTime: "6 min read"
+metaDescription: "Free server monitoring checklist 2025: pragmatic steps to get infrastructure visibility without paying for bloated APM suites."
+---
+
+# Free Server Monitoring Checklist 2025
+
+Stop paying for features you do not use. This checklist shows exactly how to wire up free server and infrastructure monitoring with Exit1.dev and a few pragmatic integrations.
+
+## 1. Map Critical Services First
+
+You cannot monitor what you never list. Start with the workloads that make money or keep customers from churning. Inventory:
+
+- Public API endpoints, health checks, cron jobs.
+- Internal services that trigger cascading failures when they fall over.
+- Certificate renewal workflows and DNS records.
+
+Tag everything with the same names you use inside [Free Uptime Monitor for SaaS](/blog/monitoring/free-uptime-monitor-for-saas) to keep the story straight between website monitoring and infrastructure.
+
+## 2. Wire Infrastructure Heartbeats into Exit1.dev
+
+Exit1.dev accepts simple HTTP checks, webhooks, and custom payloads. Instrument every server:
+
+- Use the built-in cron monitor to ensure background workers fire on time.
+- Expose a `/healthz` endpoint on each service and let Exit1.dev hit it every minute.
+- Ship structured logs through the [Exit1 Logs to Warehouse guide](/blog/monitoring/exit1-logs-to-warehouse-csv-excel) so your team sees anomalies fast.
+
+## 3. Add Real Alerts Where People Respond
+
+Email is a dead end. Route alerts to the rooms that trigger action:
+
+- Slack for the daily response loop using the [Slack integration playbook](/blog/monitoring/free-uptime-monitor-slack-integration).
+- PagerDuty or Opsgenie through webhooks for true after-hours escalation.
+- Discord for community or open-source projects that live there.
+
+Set alert fatigue boundaries. Infrastructure monitoring is worthless if everyone mutes the channel.
+
+## 4. Track Infrastructure SLAs Automatically
+
+Business stakeholders care about reliability trends, not excuses. Turn your uptime data into SLA dashboards:
+
+- Reuse the [Free SLA monitoring guide](/blog/monitoring/free-sla-monitoring-guide) to translate availability into promises.
+- Generate monthly reports straight from Exit1.dev so finance and sales see proof, not hopes.
+- Export to CSV and attach context from post-incident reviews.
+
+## 5. Close the Loop with Incident Reviews
+
+Every failure should improve the checklist. Run postmortems and push the learnings into automation:
+
+- Capture root causes inside Exit1.dev incident timelines.
+- Update monitors any time infrastructure changes.
+- Build a library of fix-once runbooks inspired by the [Incident Postmortem templates](/blog/monitoring/incident-postmortem-templates-with-exit1).
+
+## The Result: Infrastructure Monitoring That Holds Up
+
+This free checklist gives you actual server visibility without signing a single enterprise contract. The only "secret" is staying disciplined and ruthless about signal-to-noise. Exit1.dev does the heavy lifting; you just need the courage to cut the fluff.

--- a/src/content/posts/infrastructure-monitoring/sre-playbook-free-infrastructure-monitoring.md
+++ b/src/content/posts/infrastructure-monitoring/sre-playbook-free-infrastructure-monitoring.md
@@ -1,0 +1,55 @@
+---
+title: "SRE Playbook: Free Infrastructure Monitoring for Hybrid Clouds"
+author: "Morten Pradsgaard"
+date: "2025-02-18"
+category: "infrastructure-monitoring"
+excerpt: "Run hybrid infrastructure without blowing the budget. A blunt SRE playbook for free server monitoring."
+readTime: "7 min read"
+metaDescription: "SRE playbook for free infrastructure monitoring across hybrid cloud and on-prem. Use Exit1.dev plus automation to stay ahead."
+---
+
+# Hybrid Cloud SRE Playbook for Free Infrastructure Monitoring
+
+Hybrid infrastructure is messy by default. That is no excuse to bleed cash on tools. Here is how to run a disciplined monitoring program for free.
+
+## Establish a Single Source of Truth
+
+Hybrid teams drown in dashboards. Pick Exit1.dev as the external heartbeat so every environment gets judged by the same metrics. Mirror the monitor tags you used in the [agency uptime playbook](/blog/monitoring/agency-msp-free-uptime-monitor-playbook) to keep client segments tidy.
+
+## Standardize Health Endpoints Across Clouds
+
+- Wrap legacy VMs with lightweight HTTP health endpoints.
+- Use Kubernetes readiness probes and point Exit1.dev checks at the ingress so you test the real path customers hit.
+- Validate certificates and DNS with the [free SSL monitoring guides](/blog/monitoring/free-ssl-monitoring-alerts-made-easy-and-why-it-matters).
+
+## Automate Onboarding of New Infrastructure
+
+Connect your infrastructure-as-code pipelines to Exit1.dev:
+
+1. Terraform applies fire a webhook that registers new monitors.
+2. GitHub Actions run smoke tests and feed results into the [real-time alert workflow](/blog/monitoring/importance-of-real-time-alerts).
+3. Pull request templates include links to affected monitors so reviewers catch blind spots.
+
+## Keep Escalations Honest
+
+Hybrid means time zones. Use tiered routing:
+
+- Slack for on-call rotations that cover both cloud and colo assets.
+- SMS or phone via Zapier when a region drops and your main comms tool is down.
+- Status page automation from Exit1.dev incidents so customers see progress, not silence.
+
+## Learn from Every Outage
+
+Postmortems should bridge gaps between clouds:
+
+- Use the [incident management templates](/blog/monitoring/incident-postmortem-templates-with-exit1) to document what broke where.
+- Update runbooks inside the [incident response hub](/blog/incident-management/) so context is not lost.
+- Share uptime and SLA charts with leadership via the [SLA reporting stack](/blog/monitoring/sla-reporting-free-uptime-stack).
+
+## Why Free Infrastructure Monitoring Wins Hybrid
+
+- You break silos by unifying external checks and internal metrics.
+- Teams focus on fixes instead of negotiating license tiers.
+- The savings fund better redundancy instead of dashboards nobody opens.
+
+Ship this playbook and your hybrid cloud stops feeling like roulette.


### PR DESCRIPTION
## Summary
- add a Server & Infrastructure Monitoring blog category to support infrastructure-focused topics
- publish four new long-form articles targeting free server and infrastructure monitoring keywords
- deepen internal linking between infrastructure pieces and existing uptime, SLA, and incident resources

## Testing
- not run (content changes only)

------
https://chatgpt.com/codex/tasks/task_b_690d3cf4f10c8325be4efb1c507a6823