### PR TITLE
Add API monitoring category with new content cluster

### DIFF
--- a/src/content/blog.json
+++ b/src/content/blog.json
@@ -31,6 +31,12 @@
       "name": "Server & Infrastructure Monitoring",
       "description": "Hybrid cloud uptime, infrastructure visibility, and free server monitoring tactics",
       "slug": "infrastructure-monitoring"
+    },
+    {
+      "id": "api-monitoring",
+      "name": "API & Endpoint Monitoring",
+      "description": "Monitor REST, GraphQL, and microservice endpoints with free uptime and deep validation tactics",
+      "slug": "api-endpoint-monitoring"
     }
   ]
 }

--- a/src/content/posts/api-monitoring/api-endpoint-monitoring-playbook-2025.md
+++ b/src/content/posts/api-monitoring/api-endpoint-monitoring-playbook-2025.md
@@ -1,0 +1,80 @@
+---
+title: "API Endpoint Monitoring Playbook 2025"
+author: "Morten Pradsgaard"
+category: "api-monitoring"
+excerpt: "Instrument every endpoint like your revenue depends on it. JSON validation, auth watchdogs, and synthetic flows that keep APIs honest."
+date: "2025-02-25"
+metaDescription: "Build a no-compromise API endpoint monitoring playbook with exit1.dev. Validate payloads, auth, and performance without paying enterprise rates."
+---
+
+# API Endpoint Monitoring Playbook 2025
+
+APIs run your product, your billing, and your brand. Ship broken responses and customers churn before sales can send their "sorry" emails. This playbook gives you the straight line to number-one ranking for "API endpoint monitoring" and, more importantly, zero-surprise incidents.
+
+## Start with ruthless coverage
+
+Stop guessing which endpoints matter. Inventory every REST, GraphQL, gRPC, and webhook path by:
+
+1. Pulling routes from your gateway or service mesh.
+2. Mapping them to business capabilities (auth, checkout, billing, notifications, partner integrations).
+3. Prioritizing the endpoints where a single failure punches revenue.
+
+Now wire each critical path into exit1.dev monitors. Point the health check to production first. Then mirror the same check in staging so you catch regressions before they hit real money.
+
+### Monitor beyond status codes
+
+A 200 response hiding an error payload is a lie. exit1.dev stops that nonsense with:
+
+- JSONPath assertions like `$.data.status == "ok"`.
+- Header checks so missing auth tokens throw alerts.
+- Body keyword scans for legacy XML or HTML flows.
+
+Need a refresher on JSON specifics? Steal the tricks from [GraphQL and API Uptime Guardrails](/blog/graphql-api-uptime-guardrails) and apply them everywhere.
+
+## Synthetic flows keep contracts honest
+
+Single endpoints tell you latency. Synthetic workflows prove the integration still works. Chain monitors to:
+
+- Hit auth, receive a JWT, and reuse it.
+- Submit a cart, expect a 201 plus SKU payload.
+- Trigger outbound webhooks and validate your callback endpoint catches them.
+
+Pair those workflows with the [Free Uptime Monitor Checklist](/blog/free-uptime-monitor-checklist) to keep documentation and response procedures tight.
+
+## Regional and dependency awareness
+
+Latency spikes in Sydney won’t show up if you only probe from Virginia. exit1.dev’s global regions make the difference. Run each critical API monitor from:
+
+- One primary region where your users live.
+- One failover region where your disaster recovery setup sits.
+- One wildcard region for cold-start detection.
+
+Map dependencies explicitly. If your API depends on external PSPs or SaaS, add monitors for their status endpoints too. When Stripe fumbles, you’ll know it’s not your code.
+
+## Alerting without noise
+
+You can’t ship reliable APIs if every alert is a fire drill. Tune exit1.dev channels like this:
+
+- **Slack**: Engineers see failures instantly. Thread the alert with runbooks, and link back to [Incident Postmortem Templates](/blog/incident-postmortem-templates-with-exit1) so lessons stick.
+- **Email**: Execs get summaries. Reuse the patterns from [Free Uptime Monitor Email Alerts](/blog/free-uptime-monitor-email-alerts).
+- **Webhook**: Pipe to PagerDuty or custom incident bots.
+
+Escalate only when monitors fail twice in a row. One fluke shouldn’t wake anyone up.
+
+## Reporting that earns trust
+
+Product, sales, and compliance want proof that APIs stay up. Build reports that matter:
+
+- Weekly uptime summaries by endpoint family.
+- Error budget consumption tied to the SLA commitments you made in [Free SLA Monitoring Guide](/blog/free-sla-monitoring-guide).
+- Post-incident retros that link alert timestamps, owner, fix time, and future prevention.
+
+Export raw data into your warehouse via exit1.dev webhooks. Correlate with customer churn, support tickets, and revenue dips. That’s how you get buy-in for reliability budget.
+
+## Next actions
+
+- [Start monitoring APIs for free](https://app.exit1.dev/) and import your first 25 endpoints.
+- Share this playbook with engineering leadership so they stop pretending endpoint monitoring is optional.
+- Queue up the deeper dive in [API Error Budgets and SLAs](/blog/api-error-budgets-sla) once you define your targets.
+
+Stay paranoid, automate everything, and own your APIs before outages own you.

--- a/src/content/posts/api-monitoring/api-error-budgets-sla.md
+++ b/src/content/posts/api-monitoring/api-error-budgets-sla.md
@@ -1,0 +1,64 @@
+---
+title: "API Error Budgets and SLA Math That Actually Works"
+author: "Morten Pradsgaard"
+category: "api-monitoring"
+excerpt: "Define uptime targets for APIs that don’t blow up engineering velocity. Convert error budgets into monitors, alerts, and honest dashboards."
+date: "2025-02-25"
+metaDescription: "Set API error budgets, SLAs, and SLOs using exit1.dev. Learn how to map budgets to monitors, alerts, and executive reporting that proves reliability."
+---
+
+# API Error Budgets and SLA Math That Actually Works
+
+Executives love promising "five nines" while your APIs still bleed 500s. This guide shows you how to set real error budgets, wire them into exit1.dev, and enforce SLAs without hand-wavy spreadsheets.
+
+## Nail the reliability targets first
+
+Forget vanity numbers. Pick metrics tied to customer pain:
+
+- **Availability**: Percentage of successful responses (`2xx` plus the payload validations from the [API Endpoint Monitoring Playbook 2025](/blog/api-endpoint-monitoring-playbook-2025)).
+- **Latency**: 95th percentile under contractual thresholds.
+- **Correctness**: Schema-validated payloads with no missing fields.
+
+Translate each target into an error budget. Example: 99.9% availability allows 43.2 minutes of downtime per month. Miss it and your roadmap pauses until reliability is back in compliance.
+
+## Map budgets to monitors
+
+Error budgets are useless if you don’t instrument them. exit1.dev handles it without nickel-and-diming you for extra checks:
+
+1. Create monitors per API capability (auth, checkout, billing, webhooks).
+2. Add JSONPath assertions so you catch logical failures, not just HTTP errors.
+3. Configure multi-region probes—see [Multi-Region Performance Tuning](/blog/multi-region-performance-tuning-global-probes) for the setup blueprint.
+
+Group monitors into tags like `tier:gold` and `tier:silver`. Your gold tier drives the tight SLA math. Silver tier buys you more slack.
+
+## Alert routes that respect error budgets
+
+Alert fatigue murders SLAs. Tie alerts directly to budget burn:
+
+- Send Slack pings only after two consecutive failures. Copy the approach from [Free Uptime Monitor Slack Integration](/blog/free-uptime-monitor-slack-integration).
+- Trigger PagerDuty when downtime exceeds 25% of the monthly budget.
+- Email product and customer success weekly with uptime stats so they don’t promise nonsense on sales calls.
+
+If an incident blows past the budget, run a postmortem instantly. Use the templates in [Incident Postmortem Templates with exit1.dev](/blog/incident-postmortem-templates-with-exit1) and link the final doc to your SLA tracker.
+
+## Report with brutal transparency
+
+Executives sign SLAs to close deals. Make them own the reliability reality too.
+
+- Publish a dashboard with uptime per API, latency percentiles, and remaining budget.
+- Export monitor results via webhooks to your warehouse. Combine with [Exit1 Logs to Warehouse CSV/Excel](/blog/exit1-logs-to-warehouse-csv-excel) so finance sees the same truth.
+- Include customer-impact annotations from support tickets or status page posts.
+
+When the budget goes negative, freeze new feature launches. Nothing motivates leadership like a delayed release.
+
+## Iterate without killing velocity
+
+Treat error budgets as a conversation, not a hammer. When you regularly exceed targets, ratchet them tighter. When a major migration happens, temporarily loosen the budget but document it in the SLA addendum. That balance keeps engineers shipping while customers keep trusting your APIs.
+
+## What to do next
+
+- Audit your current uptime promises against this math.
+- Wire every critical endpoint into the monitors outlined in the [API Endpoint Monitoring Playbook 2025](/blog/api-endpoint-monitoring-playbook-2025).
+- Ready to level up on automation? Jump to [API Observability Automation Toolkit](/blog/api-observability-automation-toolkit) for synthetic workflows that keep budgets intact.
+
+Error budgets aren’t theory. They’re the contract between velocity and reliability. Own them, or they’ll own you.

--- a/src/content/posts/api-monitoring/api-observability-automation-toolkit.md
+++ b/src/content/posts/api-monitoring/api-observability-automation-toolkit.md
@@ -1,0 +1,64 @@
+---
+title: "API Observability Automation Toolkit"
+author: "Morten Pradsgaard"
+category: "api-monitoring"
+excerpt: "Wire exit1.dev, logs, and status automation together so every API contract is verified automatically and incidents resolve fast."
+date: "2025-02-25"
+metaDescription: "Automate API observability with exit1.dev. Learn how to combine monitors, logs, and status automation to keep endpoints healthy and transparent."
+---
+
+# API Observability Automation Toolkit
+
+APIs sprawl faster than your team. If you’re not automating observability, you’re gambling uptime on tribal knowledge. This toolkit shows how exit1.dev becomes the automation backbone for API and endpoint monitoring.
+
+## Start with a single source of truth
+
+Throw out the fragmented spreadsheets. Use exit1.dev tags to group monitors by service (`service:billing`), tier (`tier:gold`), and customer commitment (`customer:enterprise`). That one taxonomy lets you slice uptime, latency, and budget consumption on demand.
+
+Need the foundational monitors? Start with the [API Endpoint Monitoring Playbook 2025](/blog/api-endpoint-monitoring-playbook-2025). It outlines the coverage you’ll automate here.
+
+## Automate payload validation
+
+Stop pushing manual QA to catch schema drift. Automate checks:
+
+- **JSONPath Assertions**: Validate `$.order.total` or `$.token.expires_at` to the exact value range.
+- **Header enforcement**: Require caching headers, `X-Request-ID`, or auth tokens.
+- **Negative tests**: Hit endpoints with expired tokens and confirm `401` with the right error body.
+
+Check out the JSON tricks from [GraphQL and API Uptime Guardrails](/blog/graphql-api-uptime-guardrails) to cover GraphQL, REST, and RPC variations.
+
+## Wire logs and traces to monitors
+
+Monitors fire the moment APIs break. Logs tell you why. Combine them:
+
+1. Send exit1.dev webhook alerts into your log pipeline (Datadog, OpenTelemetry, Loki).
+2. Attach monitor metadata (`service`, `environment`, `customer`) so log queries auto-filter to the failing path.
+3. Feed that context into your incident channel. Pair it with [Real-time vs 5-minute Monitoring](/blog/real-time-vs-5-minute-monitoring) to justify faster probes on fragile services.
+
+## Automate status pages and comms
+
+Customers hate silence. Automate the updates:
+
+- Trigger your status page API when a monitor fails twice.
+- Post to Slack, Discord, and email simultaneously. The workflows from [Free Uptime Monitor Slack Integration](/blog/free-uptime-monitor-slack-integration) and [Free Website Monitor Discord Integration](/blog/free-website-monitor-discord-integration) already exist.
+- When the monitor recovers, auto-close the incident and attach a link to the upcoming postmortem.
+
+## Close the loop with retrospectives
+
+Automation without learning is busywork. Bake retros into the workflow:
+
+- Once the monitor resolves, create a ticket referencing the incident.
+- Use the [Incident Postmortem Templates with exit1.dev](/blog/incident-postmortem-templates-with-exit1) to capture root cause, detection time, and prevention tasks.
+- Feed the lessons into your API backlog so the same bug never makes a comeback.
+
+## Scale across teams
+
+Platform, product, and partner teams can all share the same exit1.dev workspace. Use role-based access so teams manage their own monitors while leadership sees the full map. Add onboarding checklists for new services that reference this toolkit plus the [API Error Budgets and SLA Math](/blog/api-error-budgets-sla) guide.
+
+## Take action now
+
+- Wire your monitors into exit1.dev webhooks and automation flows.
+- Centralize dashboards so execs and ICs stare at the same truth.
+- Ship faster because you trust the guardrails.
+
+Automation is how you keep API monitoring sharp without burning engineers out. Do it now before the next incident embarrasses you.

--- a/src/content/posts/api-monitoring/platform-api-monitoring-operations-guide.md
+++ b/src/content/posts/api-monitoring/platform-api-monitoring-operations-guide.md
@@ -1,0 +1,64 @@
+---
+title: "Platform API Monitoring Operations Guide"
+author: "Morten Pradsgaard"
+category: "api-monitoring"
+excerpt: "Run platform engineering like a business unit. Build API monitoring operations that keep partner integrations, mobile apps, and internal teams running."
+date: "2025-02-25"
+metaDescription: "Operate platform APIs with confidence. Learn how exit1.dev helps platform teams monitor endpoints, manage partners, and stay compliant."
+---
+
+# Platform API Monitoring Operations Guide
+
+Platform teams sit between product and every integration that depends on your APIs. When an endpoint fails, you’re the villain. This guide shows how to run API monitoring like an operations franchise—no excuses, no blind spots.
+
+## Build a source-of-truth catalog
+
+List every endpoint, version, and owning squad. Track:
+
+- Endpoint path and method.
+- Auth model (API key, OAuth, service token).
+- Criticality tier (enterprise contract, internal tool, experimental).
+
+Feed that catalog directly into exit1.dev monitors. Use tags like `owner:payments` and `contract:platinum` so routing, reporting, and escalation stay automatic. The [API Endpoint Monitoring Playbook 2025](/blog/api-endpoint-monitoring-playbook-2025) gives you the coverage templates.
+
+## Give partners the monitoring they deserve
+
+Your external developers run businesses on your APIs. Don’t leave them guessing.
+
+- Share read-only dashboards with uptime, latency, and incident history.
+- Create a partner-facing status channel that echoes alerts from [Free Uptime Monitor Slack Integration](/blog/free-uptime-monitor-slack-integration).
+- Publish SLA performance monthly using the workflow from [API Error Budgets and SLA Math](/blog/api-error-budgets-sla).
+
+Transparency turns partners into allies instead of angry support tickets.
+
+## Enforce version discipline
+
+Zombie API versions drain resources. Monitor them with the same rigor:
+
+1. Tag monitors by version (`version:v1`, `version:v2`).
+2. When usage drops below your deprecation threshold, trigger a communication campaign.
+3. Use the automation stack from [API Observability Automation Toolkit](/blog/api-observability-automation-toolkit) to post countdowns to Slack, email, and status pages.
+
+## Incident command that scales
+
+When something breaks, response should be muscle memory:
+
+- Alerts hit Slack, email, and PagerDuty at the right severity. See [Incident Postmortem Templates with exit1.dev](/blog/incident-postmortem-templates-with-exit1) for how to close the loop.
+- Assign an incident commander instantly. They own customer comms, updates to leadership, and coordination with support.
+- Keep a live document of mitigation steps. Update it after the postmortem and link back to the monitors in exit1.dev.
+
+## Compliance and audit ready
+
+APIs power regulated workflows. Auditors want receipts.
+
+- Export uptime and alert history monthly into your governance repository.
+- Store SLA adherence metrics alongside the [Free SLA Monitoring Guide](/blog/free-sla-monitoring-guide) documents.
+- Map critical endpoints to controls like SOC 2 CC7.2 so compliance questions get resolved before the meeting ends.
+
+## Next moves for platform leaders
+
+- Share this guide with every partner manager and platform engineer.
+- Align your runbooks with the automation from [API Observability Automation Toolkit](/blog/api-observability-automation-toolkit).
+- Schedule quarterly reviews of error budgets, partner SLAs, and version plans.
+
+Run platform APIs like the business-critical products they are. Monitoring is the backbone, and exit1.dev gives you the leverage without the enterprise bill.


### PR DESCRIPTION
## Summary
- add an "API & Endpoint Monitoring" blog category to expand topical coverage
- publish a four-article content cluster covering API playbooks, error budgets, automation, and platform operations
- cross-link new posts with existing monitoring resources to strengthen internal SEO

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690d3dda3c548325afd90fe97e08c97e)