### PR TITLE
Add cronjob monitoring blog category and content

### DIFF
--- a/src/content/blog.json
+++ b/src/content/blog.json
@@ -37,6 +37,12 @@
       "name": "API & Endpoint Monitoring",
       "description": "Monitor REST, GraphQL, and microservice endpoints with free uptime and deep validation tactics",
       "slug": "api-endpoint-monitoring"
+    },
+    {
+      "id": "cronjob-monitoring",
+      "name": "Cron & Scheduled Task Monitoring",
+      "description": "Heartbeat monitoring, scheduled task reliability, and background job observability tactics",
+      "slug": "cronjob-monitoring"
     }
   ]
 }

--- a/src/content/posts/cronjob-monitoring/cronjob-monitoring-metrics-that-matter.md
+++ b/src/content/posts/cronjob-monitoring/cronjob-monitoring-metrics-that-matter.md
@@ -1,0 +1,42 @@
+---
+title: "Cronjob Monitoring Metrics That Actually Matter"
+author: "Morten Pradsgaard"
+category: "cronjob-monitoring"
+excerpt: "Focus cron monitoring on the metrics that predict failure: cadence, delay, duration, and downstream impact. Ditch vanity charts."
+date: "2025-02-18"
+metaDescription: "Measure the right cronjob monitoring metrics—cadence, delay, duration, and downstream health—with exit1.dev’s free scheduled task monitoring dashboards."
+---
+
+# Cronjob Monitoring Metrics That Actually Matter
+
+Most cron dashboards are noise: line charts nobody reads, aggregate success counts that hide the rot. exit1.dev keeps cronjob monitoring sharp by focusing on four metrics that actually predict failure.
+
+## 1. Expected cadence vs. observed cadence
+
+Track how often the job *should* run versus how often it actually pings exit1.dev. A missing run is failure, not a rounding error. Plot cadence drift and alert on a single miss. Anything softer invites customer-facing outages.
+
+## 2. Start-to-finish duration
+
+Duration spikes point to upstream issues. Compare each run’s `duration_ms` payload against the historical median. Alert when it doubles. That’s how you catch slow databases before they time out, and it’s baked into exit1.dev’s JSON assertions.
+
+## 3. Time-to-detect and time-to-resolve
+
+Measure how long it takes to notice and fix a failed cron. Pair exit1.dev alerts with [incident response playbooks](/blog/incident-postmortem-templates-with-exit1) so you can tighten the loop. You should know within minutes, not hours.
+
+## 4. Downstream impact checks
+
+If the cron populates a cache or triggers an email campaign, monitor that surface too. Use our [Free Website Monitoring Tools 2025 Guide](/blog/free-website-monitoring-tools-2025) to set up HTTP or API checks that confirm the scheduled task actually delivered.
+
+## Bonus: combine cron and SLA reporting
+
+Roll cron reliability into your SLO reviews. [SLA Reporting with a Free Uptime Stack](/blog/sla-reporting-free-uptime-stack) shows how to put exit1.dev data into client-facing decks. When you can prove scheduled tasks hit their targets, contract renewals get easier.
+
+## Internal linking that matters
+
+Keep readers moving through the site:
+
+- From cron monitoring posts, link to [Free Uptime Monitor vs Paid](/blog/free-uptime-monitor-vs-paid) for context on why our free tier punches above its weight.
+- Point operators to [Real-Time vs 5 Minute Monitoring](/blog/real-time-vs-5-minute-monitoring) when they argue over alert frequency.
+- Reference [Free SLA Monitoring Guide](/blog/free-sla-monitoring-guide) when compliance teams show up.
+
+Stay focused on these metrics and cronjob monitoring becomes predictable, measurable, and finally respected.

--- a/src/content/posts/cronjob-monitoring/cronjob-monitoring-playbook-free-scheduled-task-observability.md
+++ b/src/content/posts/cronjob-monitoring/cronjob-monitoring-playbook-free-scheduled-task-observability.md
@@ -1,0 +1,52 @@
+---
+title: "Cronjob Monitoring Playbook: Free Scheduled Task Observability"
+author: "Morten Pradsgaard"
+category: "cronjob-monitoring"
+excerpt: "Cron jobs deserve ruthless monitoring. Here’s the free, opinionated playbook to keep every scheduled task visible and honest."
+date: "2025-02-18"
+metaDescription: "Learn the exact cronjob monitoring playbook to instrument scheduled tasks with exit1.dev. Cover heartbeats, payload checks, routing, and dashboards without paying a cent."
+---
+
+# Cronjob Monitoring Playbook: Free Scheduled Task Observability
+
+Cron jobs are the janitors of your platform. When they fail, customer-facing uptime numbers stay green while data rots. exit1.dev fixes that with a free heartbeat monitor that refuses to miss a job. If you want "set it and forget it" operations, go elsewhere. If you want ruthless visibility, read on.
+
+## Step 1: Inventory the jobs you actually rely on
+
+Most teams don’t know how many scheduled tasks they run. List them. Tag every cronjob, queue worker, and timed Lambda. If it changes state or data, it gets a monitor. Skip this and you’ll only find out what exists when something burns down.
+
+Use [our website monitoring checklist](/blog/free-uptime-monitor-checklist) as a baseline. Then layer cron-specific metadata: cadence, owner, last rewrite, timeout, blast radius.
+
+## Step 2: Wire up heartbeats in minutes
+
+1. Create a new monitor in exit1.dev and choose **Heartbeat / Cron**.
+2. Drop the generated URL into your job. Curl it when the run finishes.
+3. Set the expected interval tighter than the job schedule. If the job runs hourly, enforce 65 minutes, not 90.
+
+You now have a watchdog that screams when the job disappears. Pair it with [our HTTP hook guide](/blog/cron-job-worker-monitoring-http-hooks) to fan out start/finish pings if you want redundancy.
+
+## Step 3: Validate payloads, not just presence
+
+Heartbeat-only monitoring is lazy. Send JSON alongside the ping with fields like `duration_ms`, `records_processed`, and `result`. exit1.dev lets you assert JSONPath expressions so you catch "succeeded": false states before support tickets pile up.
+
+Add a second synthetic monitor to the API that the job feeds. If a nightly import fails, the next request should fail too. [Intro to website monitoring](/blog/website-monitoring-101) shows how to chain checks without getting buried in noise.
+
+## Step 4: Route alerts like you mean it
+
+Route business-critical jobs to PagerDuty or Opsgenie. Ship "nice to have" scripts to Slack or Discord. Because the monitors are free, you can split them by team or service. Don’t throw everything into a single #alerts channel and hope the right person notices.
+
+## Step 5: Report the wins
+
+Exit1.dev stores run history forever. Export cron stats with our CSV warehouse workflow in [Logs to Warehouse](/blog/exit1-logs-to-warehouse-csv-excel). Show leadership how many jobs tried to self-destruct and how fast you responded. SLO reports aren’t just for customer-facing incidents anymore.
+
+## Step 6: Keep the dashboards honest
+
+Pin your critical jobs inside the uptime dashboard next to customer-facing monitors. The point is one cockpit: web, API, workers, and scheduled tasks in the same place. If you’re still flipping between crontabs and Grafana, you’re wasting time.
+
+## Related playbooks
+
+- [Monitor Cron Jobs and Workers with HTTP Hooks](/blog/cron-job-worker-monitoring-http-hooks)
+- [SLA Reporting with a Free Uptime Stack](/blog/sla-reporting-free-uptime-stack)
+- [Free Uptime Monitor for SaaS](/blog/free-uptime-monitor-for-saas)
+
+Set this up once and cronjob failures stop being surprises. exit1.dev gives you the guardrails. Your team just has to use them.

--- a/src/content/posts/cronjob-monitoring/free-cronjob-monitor-setup-serverless-schedules.md
+++ b/src/content/posts/cronjob-monitoring/free-cronjob-monitor-setup-serverless-schedules.md
@@ -1,0 +1,56 @@
+---
+title: "Free Cronjob Monitor Setup for Serverless Schedules"
+author: "Morten Pradsgaard"
+category: "cronjob-monitoring"
+excerpt: "Wire up Lambda, Cloud Functions, and Workers with free cron monitoring. No extra infra, just precise heartbeats and payload checks."
+date: "2025-02-18"
+metaDescription: "Set up a free cronjob monitor for serverless schedules using exit1.dev. Learn how to add heartbeats, payload validation, and smart alert routing without extra infrastructure."
+---
+
+# Free Cronjob Monitor Setup for Serverless Schedules
+
+Serverless schedulers promise simplicity. Then a function stalls and you find out three days later. exit1.dev gives you free cron monitoring that keeps Lambda, Cloudflare Workers, and Cloud Functions honest.
+
+## 1. Create the heartbeat monitor
+
+Open exit1.dev, add a new monitor, and select **Cron / Heartbeat**. Name it after the scheduled function, tag it with the team, and set the interval equal to the schedule plus a buffer.
+
+## 2. Ping from your function
+
+Add a POST request to the monitor URL at the end of the handler:
+
+```javascript
+await fetch(process.env.EXIT1_MONITOR_URL, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    status: "success",
+    duration_ms: duration,
+    region: context.invokedFunctionArn?.split(":")[3]
+  })
+});
+```
+
+Use environment variables for the monitor URL so you can rotate it without redeploying. Keep the payload lean—only the numbers you’ll actually assert.
+
+## 3. Assert on payloads
+
+Inside exit1.dev, add JSONPath rules like `$.status == "success"` and `$.duration_ms < 60000`. Failures trigger alerts even if the heartbeat fires, catching partial work or slow runs.
+
+## 4. Route alerts per environment
+
+Send production failures to PagerDuty or Slack. Point staging or nightly jobs to email digests. Unlimited integrations mean you don’t have to choose. Combine with [Free Uptime Monitor Email Alerts](/blog/free-uptime-monitor-email-alerts) to keep execs informed without giving them dashboard logins.
+
+## 5. Track runtime drift
+
+Exit1.dev keeps run history, so you can plot duration creep over time. When a job suddenly takes 2x longer, you’ll see it before the cloud bill spikes. Export data to spreadsheets with [Logs to Warehouse](/blog/exit1-logs-to-warehouse-csv-excel) for monthly reviews.
+
+## 6. Cover dependencies
+
+Monitor the API, database, or queue your function touches. The [Free Website Monitor for Developers](/blog/free-website-monitoring-for-developers) article shows how to stack HTTP checks, SSL alerts, and cron monitors in one place.
+
+## 7. Fail fast in staging
+
+Clone your heartbeat monitor for staging and shorten the interval. Force a failure before every release by blocking the outbound ping. If no alert fires, your monitoring is broken. Fix that before shipping.
+
+Serverless should mean less infrastructure, not less visibility. exit1.dev makes cronjob monitoring free, fast, and brutally honest.

--- a/src/content/posts/cronjob-monitoring/scheduled-task-monitoring-checklist-heartbeats-retries-alerts.md
+++ b/src/content/posts/cronjob-monitoring/scheduled-task-monitoring-checklist-heartbeats-retries-alerts.md
@@ -1,0 +1,54 @@
+---
+title: "Scheduled Task Monitoring Checklist: Heartbeats, Retries, Alerts"
+author: "Morten Pradsgaard"
+category: "cronjob-monitoring"
+excerpt: "A punchy checklist to monitor cron jobs, serverless schedules, and background workers without buying bloated tooling."
+date: "2025-02-18"
+metaDescription: "Use this scheduled task monitoring checklist to cover heartbeats, retries, alert routing, and reporting with exit1.dev’s free cronjob monitoring."
+---
+
+# Scheduled Task Monitoring Checklist: Heartbeats, Retries, Alerts
+
+There’s no glory in scheduled task reliability, but there’s hell to pay when it slips. This checklist keeps cron jobs and serverless schedules observable with exit1.dev’s free stack. Run it every quarter and before every major launch.
+
+## 1. Document cadence and purpose
+
+Write down why the job exists, when it runs, and what happens if it fails. If the answer is "not sure", delete it or fix the owner. Shadow cron jobs are operational debt.
+
+## 2. Configure exit1.dev heartbeats
+
+- Create a **Cron / Heartbeat** monitor per task.
+- Use distinct tags like `billing`, `analytics`, or `ops` so you can filter dashboards.
+- Set the interval slightly tighter than the schedule.
+
+If you need help with the HTTP call, the [cron hook playbook](/blog/cron-job-worker-monitoring-http-hooks) shows copy/paste examples.
+
+## 3. Capture execution metadata
+
+Send payloads with `duration`, `records`, or custom metrics. Assert on them so "success" means healthy output, not just "job ran". Tie this into [Free SLA Monitoring Tools](/blog/free-sla-monitoring-tools) to surface the data in client reports.
+
+## 4. Route alerts with intent
+
+- PagerDuty / Opsgenie: revenue-impacting tasks.
+- Slack / Discord: supporting jobs that still deserve visibility.
+- Email digests: long-running but low urgency tasks.
+
+Split alerts per team or service. exit1.dev doesn’t charge for integrations, so be generous.
+
+## 5. Verify retries
+
+If a job fails, how does it recover? Document whether the script retries automatically, if you re-run manually, or if there’s a queue to drain. Test the failure path once a quarter. Trusting untested retries is naive.
+
+## 6. Instrument dependencies
+
+Monitor the API or database the task depends on. When the cron fails, you need to know whether the upstream service caused it. [Website Monitoring Best Practices 2025](/blog/website-monitoring-best-practices-2025) outlines how to build a layered view.
+
+## 7. Keep stakeholders in the loop
+
+Share dashboards or export CSVs straight from exit1.dev. Bundle cron performance into the same SLO review you already run for customer-facing uptime.
+
+## 8. Run postmortems
+
+When a scheduled task fails, treat it like any incident. Use the [incident postmortem template](/blog/incident-postmortem-templates-with-exit1) to capture timeline, impact, and follow-up. Cron failures that touch billing, analytics, or email campaigns deserve the same rigor.
+
+Print this checklist, run it like a ritual, and your scheduled tasks stop being black boxes. That’s how you keep the number one spot for cronjob monitoring.


### PR DESCRIPTION
## Summary
- add a Cron & Scheduled Task Monitoring category to the blog metadata
- publish four long-form cronjob monitoring articles targeting scheduled task keywords and deep internal linking
- emphasize exit1.dev heartbeat setup, payload validation, routing, and reporting workflows for cron visibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_690d3ea530048325b4bcf84959f2d982