### PR TITLE
Adjust fall 2025 dates for monitoring blog series

### DIFF
--- a/src/content/posts/api-monitoring/api-endpoint-monitoring-playbook-2025.md
+++ b/src/content/posts/api-monitoring/api-endpoint-monitoring-playbook-2025.md
@@ -3,7 +3,7 @@ title: "API Endpoint Monitoring Playbook 2025"
 author: "Morten Pradsgaard"
 category: "api-monitoring"
 excerpt: "Instrument every endpoint like your revenue depends on it. JSON validation, auth watchdogs, and synthetic flows that keep APIs honest."
-date: "2025-02-25"
+date: "2025-09-02"
 metaDescription: "Build a no-compromise API endpoint monitoring playbook with exit1.dev. Validate payloads, auth, and performance without paying enterprise rates."
 ---
 

--- a/src/content/posts/api-monitoring/api-error-budgets-sla.md
+++ b/src/content/posts/api-monitoring/api-error-budgets-sla.md
@@ -3,7 +3,7 @@ title: "API Error Budgets and SLA Math That Actually Works"
 author: "Morten Pradsgaard"
 category: "api-monitoring"
 excerpt: "Define uptime targets for APIs that don’t blow up engineering velocity. Convert error budgets into monitors, alerts, and honest dashboards."
-date: "2025-02-25"
+date: "2025-09-12"
 metaDescription: "Set API error budgets, SLAs, and SLOs using exit1.dev. Learn how to map budgets to monitors, alerts, and executive reporting that proves reliability."
 ---
 

--- a/src/content/posts/api-monitoring/api-observability-automation-toolkit.md
+++ b/src/content/posts/api-monitoring/api-observability-automation-toolkit.md
@@ -3,7 +3,7 @@ title: "API Observability Automation Toolkit"
 author: "Morten Pradsgaard"
 category: "api-monitoring"
 excerpt: "Wire exit1.dev, logs, and status automation together so every API contract is verified automatically and incidents resolve fast."
-date: "2025-02-25"
+date: "2025-09-22"
 metaDescription: "Automate API observability with exit1.dev. Learn how to combine monitors, logs, and status automation to keep endpoints healthy and transparent."
 ---
 

--- a/src/content/posts/api-monitoring/platform-api-monitoring-operations-guide.md
+++ b/src/content/posts/api-monitoring/platform-api-monitoring-operations-guide.md
@@ -3,7 +3,7 @@ title: "Platform API Monitoring Operations Guide"
 author: "Morten Pradsgaard"
 category: "api-monitoring"
 excerpt: "Run platform engineering like a business unit. Build API monitoring operations that keep partner integrations, mobile apps, and internal teams running."
-date: "2025-02-25"
+date: "2025-10-02"
 metaDescription: "Operate platform APIs with confidence. Learn how exit1.dev helps platform teams monitor endpoints, manage partners, and stay compliant."
 ---
 

--- a/src/content/posts/cronjob-monitoring/cronjob-monitoring-metrics-that-matter.md
+++ b/src/content/posts/cronjob-monitoring/cronjob-monitoring-metrics-that-matter.md
@@ -3,7 +3,7 @@ title: "Cronjob Monitoring Metrics That Actually Matter"
 author: "Morten Pradsgaard"
 category: "cronjob-monitoring"
 excerpt: "Focus cron monitoring on the metrics that predict failure: cadence, delay, duration, and downstream impact. Ditch vanity charts."
-date: "2025-02-18"
+date: "2025-09-04"
 metaDescription: "Measure the right cronjob monitoring metrics—cadence, delay, duration, and downstream health—with exit1.dev’s free scheduled task monitoring dashboards."
 ---
 

--- a/src/content/posts/cronjob-monitoring/cronjob-monitoring-playbook-free-scheduled-task-observability.md
+++ b/src/content/posts/cronjob-monitoring/cronjob-monitoring-playbook-free-scheduled-task-observability.md
@@ -3,7 +3,7 @@ title: "Cronjob Monitoring Playbook: Free Scheduled Task Observability"
 author: "Morten Pradsgaard"
 category: "cronjob-monitoring"
 excerpt: "Cron jobs deserve ruthless monitoring. Here’s the free, opinionated playbook to keep every scheduled task visible and honest."
-date: "2025-02-18"
+date: "2025-09-14"
 metaDescription: "Learn the exact cronjob monitoring playbook to instrument scheduled tasks with exit1.dev. Cover heartbeats, payload checks, routing, and dashboards without paying a cent."
 ---
 

--- a/src/content/posts/cronjob-monitoring/free-cronjob-monitor-setup-serverless-schedules.md
+++ b/src/content/posts/cronjob-monitoring/free-cronjob-monitor-setup-serverless-schedules.md
@@ -3,7 +3,7 @@ title: "Free Cronjob Monitor Setup for Serverless Schedules"
 author: "Morten Pradsgaard"
 category: "cronjob-monitoring"
 excerpt: "Wire up Lambda, Cloud Functions, and Workers with free cron monitoring. No extra infra, just precise heartbeats and payload checks."
-date: "2025-02-18"
+date: "2025-09-24"
 metaDescription: "Set up a free cronjob monitor for serverless schedules using exit1.dev. Learn how to add heartbeats, payload validation, and smart alert routing without extra infrastructure."
 ---
 

--- a/src/content/posts/cronjob-monitoring/scheduled-task-monitoring-checklist-heartbeats-retries-alerts.md
+++ b/src/content/posts/cronjob-monitoring/scheduled-task-monitoring-checklist-heartbeats-retries-alerts.md
@@ -3,7 +3,7 @@ title: "Scheduled Task Monitoring Checklist: Heartbeats, Retries, Alerts"
 author: "Morten Pradsgaard"
 category: "cronjob-monitoring"
 excerpt: "A punchy checklist to monitor cron jobs, serverless schedules, and background workers without buying bloated tooling."
-date: "2025-02-18"
+date: "2025-10-03"
 metaDescription: "Use this scheduled task monitoring checklist to cover heartbeats, retries, alert routing, and reporting with exit1.dev’s free cronjob monitoring."
 ---
 

--- a/src/content/posts/incident-management/free-incident-management-runbook.md
+++ b/src/content/posts/incident-management/free-incident-management-runbook.md
@@ -3,7 +3,7 @@ title: "The Free Incident Management Runbook Your Team Will Actually Use"
 author: "Morten Pradsgaard"
 category: "incident"
 excerpt: "Codify incident response without bureaucratic bloat. This exit1.dev-powered runbook keeps teams fast, honest, and unblocked."
-date: "2025-03-09"
+date: "2025-09-10"
 metaDescription: "Create a free incident management runbook backed by exit1.dev monitoring. Define triggers, roles, and recovery steps without paying for enterprise tooling."
 ---
 

--- a/src/content/posts/incident-management/free-incident-management-toolkit.md
+++ b/src/content/posts/incident-management/free-incident-management-toolkit.md
@@ -3,7 +3,7 @@ title: "Free Incident Management Toolkit: Alerts, Automations, and Accountabilit
 author: "Morten Pradsgaard"
 category: "incident"
 excerpt: "Assemble a free incident management toolkit powered by exit1.dev. Ship faster recoveries without begging finance for budget."
-date: "2025-03-09"
+date: "2025-09-20"
 metaDescription: "Assemble a free incident management toolkit using exit1.dev. Combine alerts, automations, and accountability workflows to run serious incident response without paying enterprise fees."
 ---
 

--- a/src/content/posts/incident-management/free-incident-management-war-room.md
+++ b/src/content/posts/incident-management/free-incident-management-war-room.md
@@ -3,7 +3,7 @@ title: "Run a Free Incident Management War Room that Actually Resolves Things"
 author: "Morten Pradsgaard"
 category: "incident"
 excerpt: "Turn exit1.dev alerts into a disciplined war room. Crisp roles, async updates, and a bias toward recovery over chatter."
-date: "2025-03-09"
+date: "2025-09-30"
 metaDescription: "Build a no-cost incident management war room using exit1.dev. Structure roles, communication, and recovery workflows without paying for enterprise incident software."
 ---
 

--- a/src/content/posts/incident-management/free-incident-management-with-exit1.md
+++ b/src/content/posts/incident-management/free-incident-management-with-exit1.md
@@ -3,7 +3,7 @@ title: "Free Incident Management with exit1.dev: The Pragmatic Stack"
 author: "Morten Pradsgaard"
 category: "incident"
 excerpt: "Run disciplined, free incident management without adding cruft. exit1.dev gives you alerts, evidence, and collaboration glue."
-date: "2025-03-09"
+date: "2025-10-07"
 metaDescription: "Build a free incident management practice with exit1.dev. Combine real-time alerts, evidence, and collaboration workflows without paying enterprise prices."
 ---
 

--- a/src/content/posts/infrastructure-monitoring/free-infrastructure-monitoring-stack.md
+++ b/src/content/posts/infrastructure-monitoring/free-infrastructure-monitoring-stack.md
@@ -1,7 +1,7 @@
 ---
 title: "Build a Free Infrastructure Monitoring Stack with Exit1.dev"
 author: "Morten Pradsgaard"
-date: "2025-02-16"
+date: "2025-09-16"
 category: "infrastructure-monitoring"
 excerpt: "Design a no-budget server monitoring stack that still gives full observability. Exit1.dev plus proven open-source tools."
 readTime: "7 min read"

--- a/src/content/posts/infrastructure-monitoring/free-infrastructure-monitoring-tools-comparison-2025.md
+++ b/src/content/posts/infrastructure-monitoring/free-infrastructure-monitoring-tools-comparison-2025.md
@@ -1,7 +1,7 @@
 ---
 title: "Free Infrastructure Monitoring Tools 2025: Exit1.dev vs. The Rest"
 author: "Morten Pradsgaard"
-date: "2025-02-17"
+date: "2025-09-26"
 category: "infrastructure-monitoring"
 excerpt: "Compare free server and infrastructure monitoring options. Learn why Exit1.dev outruns legacy free tiers in 2025."
 readTime: "8 min read"

--- a/src/content/posts/infrastructure-monitoring/free-server-monitoring-checklist-2025.md
+++ b/src/content/posts/infrastructure-monitoring/free-server-monitoring-checklist-2025.md
@@ -1,7 +1,7 @@
 ---
 title: "Free Server Monitoring Checklist 2025: No-Compromise Infrastructure Visibility"
 author: "Morten Pradsgaard"
-date: "2025-02-15"
+date: "2025-09-06"
 category: "infrastructure-monitoring"
 excerpt: "Build a no-cost infrastructure monitoring checklist that actually keeps servers online. Step-by-step with Exit1.dev."
 readTime: "6 min read"

--- a/src/content/posts/infrastructure-monitoring/sre-playbook-free-infrastructure-monitoring.md
+++ b/src/content/posts/infrastructure-monitoring/sre-playbook-free-infrastructure-monitoring.md
@@ -1,7 +1,7 @@
 ---
 title: "SRE Playbook: Free Infrastructure Monitoring for Hybrid Clouds"
 author: "Morten Pradsgaard"
-date: "2025-02-18"
+date: "2025-10-04"
 category: "infrastructure-monitoring"
 excerpt: "Run hybrid infrastructure without blowing the budget. A blunt SRE playbook for free server monitoring."
 readTime: "7 min read"

--- a/src/content/posts/sla/free-sla-monitoring-checklist.md
+++ b/src/content/posts/sla/free-sla-monitoring-checklist.md
@@ -1,7 +1,7 @@
 ---
 title: "Free SLA Monitoring Checklist: Weekly Rituals That Keep You Out Of Penalty Mode"
 author: "Morten Pradsgaard"
-date: "2025-02-16"
+date: "2025-09-18"
 category: "sla"
 excerpt: "Step-by-step free SLA monitoring checklist covering instrumentation, alerting, reporting, and customer communication."
 readTime: "10 min read"

--- a/src/content/posts/sla/free-sla-monitoring-for-msps.md
+++ b/src/content/posts/sla/free-sla-monitoring-for-msps.md
@@ -1,7 +1,7 @@
 ---
 title: "Free SLA Monitoring For MSPs: Protect Margins And Keep Clients Loyal"
 author: "Morten Pradsgaard"
-date: "2025-02-17"
+date: "2025-09-28"
 category: "sla"
 excerpt: "How managed service providers deliver free SLA monitoring across client fleets without burning margins or headcount."
 readTime: "11 min read"

--- a/src/content/posts/sla/free-sla-monitoring-reporting-playbook.md
+++ b/src/content/posts/sla/free-sla-monitoring-reporting-playbook.md
@@ -1,7 +1,7 @@
 ---
 title: "Free SLA Monitoring Reporting Playbook: Ship Audit-Ready Evidence On Demand"
 author: "Morten Pradsgaard"
-date: "2025-02-18"
+date: "2025-10-05"
 category: "sla"
 excerpt: "Reporting framework for free SLA monitoring teams that need executive dashboards, customer updates, and legal-ready evidence."
 readTime: "13 min read"

--- a/src/content/posts/sla/free-sla-monitoring-strategy.md
+++ b/src/content/posts/sla/free-sla-monitoring-strategy.md
@@ -1,7 +1,7 @@
 ---
 title: "Free SLA Monitoring Strategy: Nail Commitments Without Paying Enterprise Tax"
 author: "Morten Pradsgaard"
-date: "2025-02-15"
+date: "2025-09-08"
 category: "sla"
 excerpt: "Blueprint for building a free SLA monitoring strategy that satisfies legal, ops, and customer success without bloated software."
 readTime: "12 min read"


### PR DESCRIPTION
## Summary
- update publish dates for API, infrastructure, cron, incident, and SLA monitoring posts
- stagger timelines between early September and early October 2025 to reflect an organic publishing cadence

## Testing
- not run (content-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690d416c396c8325b8aa8fd9c1c2a480)